### PR TITLE
edit_entry shows repetition and skipping only if necessary

### DIFF
--- a/web/js/edit_entry.js.php
+++ b/web/js/edit_entry.js.php
@@ -73,6 +73,7 @@ var changeRepTypeDetails = function changeRepTypeDetails() {
 
 <?php
 // Function to change the units for the repeat interval to match the repeat type.
+// Additionally, the lines for repetition and skipping are shown/hidden.
 ?>
 var changeRepIntervalUnits = function changeRepIntervalUnits() {
     var repType = parseInt($('input[name="rep_type"]:checked').val(), 10);
@@ -100,6 +101,9 @@ var changeRepIntervalUnits = function changeRepIntervalUnits() {
     units.text(text);
 
     units.parent().toggle(repType !== <?php echo REP_NONE ?>);
+
+    $('#rep_end_date').parent().toggle(repType !== <?php echo REP_NONE ?>);
+    $('#skip').parent().toggle(repType !== <?php echo REP_NONE ?>);
   };
 
 


### PR DESCRIPTION
Previously, mrbs showed the lines for repetition and skipping, even if no repetition and skipping is possible.
2 lines of js fix this

![grafik](https://user-images.githubusercontent.com/58709258/127902866-6e4ab9c8-888d-46e0-9347-addea14a3ac4.png)
