### PR TITLE
Differentiate edit_all and other booking admin rights

### DIFF
--- a/web/ajax/del_entries.php
+++ b/web/ajax/del_entries.php
@@ -33,8 +33,8 @@ Form::checkToken();
 // Check the user is authorised for this page
 checkAuthorised(this_page());
 
-// Check that the user is a booking admin
-if (!is_book_admin())
+// Check that the user may edit other bookings
+if (!may_edit_and_view_all_bookings())
 {
   exit;
 }

--- a/web/del_entry.php
+++ b/web/del_entry.php
@@ -45,7 +45,7 @@ if ($info = get_booking_info($id, FALSE, TRUE))
   // check that the user is allowed to delete this entry
   if (isset($action) && ($action == "reject"))
   {
-    $authorised = is_book_admin($info['room_id']);
+    $authorised = may_edit_and_view_all_bookings($info['room_id']);
   }
   else
   {

--- a/web/edit_entry_handler.php
+++ b/web/edit_entry_handler.php
@@ -255,7 +255,7 @@ if (isset($id))
 // $create_by isn't set yet, but a getWritable check will be done later,
 if (!$is_ajax)
 {
-  if (!is_book_admin($rooms) || (!isset($id) && $auth['admin_can_only_book_for_self']))
+  if (!may_edit_and_view_all_bookings($rooms) || (!isset($id) && $auth['admin_can_only_book_for_self']))
   {
     if ($create_by !== $mrbs_username)
     {

--- a/web/mrbs_auth.inc
+++ b/web/mrbs_auth.inc
@@ -318,8 +318,8 @@ function getWritable($creator, $rooms=null, $all=true)
     return true;
   }
 
-  // Otherwise you have to be a (booking) admin for this room
-  if (is_book_admin($rooms))
+  // Otherwise you have to be allowed to other peoples editing
+  if (may_edit_and_view_all_bookings($rooms))
   {
     return true;
   }
@@ -378,10 +378,68 @@ function is_admin()
   return (isset($mrbs_user) && ($mrbs_user->level >= $required_level));
 }
 
+// Checks whether the current user is allowed to modify and delete other 
+// people's bookings and to approve bookings.
+//
+// $rooms can be either a single scalar value or an array of room ids.  The default
+// value for $rooms is all rooms.  (At the moment $room is ignored, but is passed here
+// so that later MRBS can be enhanced to provide fine-grained permissions.)
+//
+// $all specifies whether the user must be a booking for all $rooms, or just some of
+// them, ie at least one.
+//
+// Returns:  TRUE if the user is allowed has booking admin rights for
+//           the room(s); otherwise FALSE
+function may_edit_and_view_all_bookings($rooms=null, $all=true)
+{
+  global $min_edit_other_bookings_level;
+  global $min_booking_admin_level;
+
+  if (is_array($rooms) && (count($rooms) > 0))
+  {
+    if ($all)
+    {
+      // We want the user to be a booking admin for all the rooms,
+      // so if for any one room they are not, then return false.
+      foreach ($rooms as $room)
+      {
+        if (!may_edit_and_view_all_bookings($room))
+        {
+          return false;
+        }
+      }
+      return true;
+    }
+    else
+    {
+      // We want the user to be a booking admin for at least one room,
+      // so if there are no rooms for which they are, then return false.
+      foreach ($rooms as $room)
+      {
+        if (may_edit_and_view_all_bookings($room))
+        {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  if (is_null($rooms) && !$all)
+  {
+    // Not yet supported.  Could support it but need to decide what $rooms=null means.
+    // Does it mean all rooms in the system or just all rooms in the current area?
+    throw new \Exception('$rooms===null and $all===false not yet supported.');
+  }
+
+  $mrbs_user = session()->getCurrentUser();
+  #echo ( "<hr>may_edit_and_view_all_bookings: " . $mbrs_user->level . ", $min_edit_other_bookings_level,$min_booking_admin_level<hr>");
+
+  return (isset($mrbs_user) && ($mrbs_user->level >= min($min_edit_other_bookings_level,$min_booking_admin_level)));
+}
 
 // Checks whether the current user has booking administration rights
-// for $rooms - ie is allowed to modify and delete other people's bookings
-// and to approve bookings.
+// for $rooms.
 //
 // $rooms can be either a single scalar value or an array of room ids.  The default
 // value for $rooms is all rooms.  (At the moment $room is ignored, but is passed here

--- a/web/report.php
+++ b/web/report.php
@@ -1601,7 +1601,7 @@ if ($phase == 2)
   // to make sure we respect the privacy settings.  (We rely on the privacy fields
   // in the area table being not NULL.   If they are by some chance NULL, then no
   // entries will be found, which is at least safe from the privacy viewpoint)
-  if (!$cli_mode && !is_book_admin())
+  if (!$cli_mode && !may_edit_and_view_all_bookings())
   {
     if (isset($mrbs_user))
     {

--- a/web/search.php
+++ b/web/search.php
@@ -292,7 +292,7 @@ if (count($invisible_room_ids) > 0)
 // to make sure we respect the privacy settings.  (We rely on the privacy fields
 // in the area table being not NULL.   If they are by some chance NULL, then no
 // entries will be found, which is at least safe from the privacy viewpoint)
-if (!is_book_admin())
+if (!may_edit_and_view_all_bookings())
 {
   if (isset($mrbs_user))
   {

--- a/web/systemdefaults.inc.php
+++ b/web/systemdefaults.inc.php
@@ -821,6 +821,8 @@ $min_user_viewing_level = 2;
 // The lowest level of admin allowed to edit other users
 $min_user_editing_level = 2;
 // The lowest level of admin allowed to edit other bookings
+$min_edit_other_bookings_level = 2;
+// The lowest level for full admin aspects
 $min_booking_admin_level = 2;
 
 


### PR DESCRIPTION
I wanted to differentiate between the right to edit other bookings and other booking admin rights, because in my setup ordinary users may edit other people´s bookings.

Even though I know, that the roles branch will make this configurable, I wanted to contribute my temporary change. Perhaps it is helpful for others or for the roles branch.
