### PR TITLE
import enhacements for google calender ical

### DIFF
--- a/web/functions_ical.inc
+++ b/web/functions_ical.inc
@@ -206,6 +206,11 @@ function get_time($value, $params=null)
     $date = $value;
     $time = '000000';
   }
+  if (empty($time))
+  {
+    // defensive programming, fix, if time is not given
+    $time = '000000';
+  }
   $year = substr($date, 0, 4);
   $month = substr($date, 4, 2);
   $day = substr($date, 6, 2);

--- a/web/lang/lang.de
+++ b/web/lang/lang.de
@@ -560,14 +560,16 @@ $vocab["import_zip"]                = "Zip-Archiv, einschließlich mehrerer Date
 $vocab["import_gzip"]               = "gzip Dateien";
 $vocab["import_bzip2"]              = "bzip2 Dateien";
 $vocab["file_name"]                 = "Dateiname";
+$vocab["url"]                       = "Url";
 $vocab["import"]                    = "Importieren";
 $vocab["upload_failed"]             = "Hochladen mit Fehler abgebrochen";
-$vocab["max_allowed_file_size"]     = "Die naximale Dateigröße beträgt";
+$vocab["max_allowed_file_size"]     = "Die maximale Dateigröße beträgt";
 $vocab["no_file"]                   = "Keine Datei hochgeladen";
 $vocab["could_not_process"]         = "Import fehlgeschlagen: Datei konnte nicht verarbeiten werden";
 $vocab["badly_formed_ics"]          = "Fehlerhaft formatierte VCALENDAR-Datei";
 $vocab["default_room"]              = "Standardraum";
 $vocab["default_room_note"]         = "Raum der bei fehlender LOCATION-Eigenschaft verwendet wird";
+$vocab["area_room_parsing"]         = "Analysiere Bereich und Raum in den Ortangaben";
 $vocab["area_room_order"]           = "Reihenfolge";
 $vocab["area_room_order_note"]      = "Reihenfolg der Bereichs- und Raumnamen in der LOCATION Eigenschaft";
 $vocab["area_room"]                 = "Bereich - Raum";
@@ -577,6 +579,8 @@ $vocab["area_room_delimiter_note"]  = "Trenn-Zeichen für die Bereichs- und Raum
                                       "Wird kein Trenn-Zeichen erkannt, wird nach einem eindeutigen Raum mit dem selben " .
                                       "Namen wie die LOCATION gesucht";
 $vocab["area_room_create"]          = "Räume anlegen, wenn notwendig";
+$vocab["delete_room_bookings"]      = "Lösche ALLE Einträge in einem Raum";
+$vocab["import_past"]               = "Importiere Buchungen in der Vergangenheit";
 $vocab["default_type"]              = "Standardtyp";
 $vocab["room_does_not_exist_no_area"] = "Raum existiert nicht - kein Bereich vorhanden";
 $vocab["room_not_unique_no_area"]     = "Raumname nicht eindeutig. Ohne Bereichsangabe keine Zuordnung möglich.";
@@ -597,6 +601,7 @@ $vocab["unsupported_COUNT"]         = "COUNT wird nicht durch unterstützt";
 $vocab["no_indefinite_repeats"]     = "Wiederholungen ohne Begrenzungen werden nicht unterstützt";
 $vocab["events_imported"]           = "Veranstaltungen importiert";
 $vocab["events_not_imported"]       = "Veranstaltungen nicht importiert";
+$vocab["events_skipped"]            = "Veranstaltungen in der Vergangenheit übersprungen";
 
 // Used in DataTables
 $vocab["dt_all"]             = "Alle";

--- a/web/lang/lang.en
+++ b/web/lang/lang.en
@@ -574,6 +574,7 @@ $vocab["import_zip"]                  = "zip archives, including multiple files 
 $vocab["import_gzip"]                 = "gzip files";
 $vocab["import_bzip2"]                = "bzip2 files";
 $vocab["file_name"]                   = "File";
+$vocab["url"]                         = "Url";
 $vocab["import"]                      = "Import";
 $vocab["upload_failed"]               = "Upload failed";
 $vocab["max_allowed_file_size"]       = "The maximum allowed file size is";
@@ -582,6 +583,7 @@ $vocab["could_not_process"]           = "Import failed: could not process file";
 $vocab["badly_formed_ics"]            = "Badly formed VCALENDAR file";
 $vocab["default_room"]                = "Default room";
 $vocab["default_room_note"]           = "The room to be used if no LOCATION property is specified";
+$vocab["area_room_parsing"]           = "Parse location information for area and room names";
 $vocab["area_room_order"]             = "Order";
 $vocab["area_room_order_note"]        = "The order of the area and room names in the LOCATION property";
 $vocab["area_room"]                   = "Area-Room";
@@ -591,6 +593,8 @@ $vocab["area_room_delimiter_note"]    = "The string separating the area and room
                                         "If no delimiter is found MRBS will look for a unique room with the same " .
                                         "name as the LOCATION";
 $vocab["area_room_create"]            = "Create rooms if necessary";
+$vocab["delete_room_bookings"]        = "Delete ALL default room bookings";
+$vocab["import_past"]                 = "Import past bookings";
 $vocab["default_type"]                = "Default type";
 $vocab["room_does_not_exist_no_area"] = "room does not exist and cannot be added - no area given";
 $vocab["room_not_unique_no_area"]     = "room name is not unique.  Cannot choose which one without an area.";
@@ -611,6 +615,7 @@ $vocab["unsupported_COUNT"]           = "COUNT not yet supported by MRBS";
 $vocab["no_indefinite_repeats"]       = "Indefinite repeats not yet supported by MRBS";
 $vocab["events_imported"]             = "events imported";
 $vocab["events_not_imported"]         = "events not imported";
+$vocab["events_skipped"]              = "past events skipped";
 
 // Used in DataTables
 $vocab["dt_all"]             = "All";


### PR DESCRIPTION
Additional features:

- import from url, e.g. google calender ical
- make parsing of area/room optional
- optional delete room before import
- option to skip past

Fixes:

- defensive programming for incomplete timedate syntax

Incomplete / Issues:

- There are dependencies that are not depicted in the web form. I don´t know how to do it in an easy manner. If the URL is given, the download does not make sense. Only if the parsing is enabled, the parsing inputs make no sense. If parsing is enabled, the deletion of all bookings is not appropriate.
- I don´t know if the deletion should be allowed. In my use case, we will regularly import from a google calender.
- There is no checking for the correct syntax of the url and retrieval errors. 
- I don´t know how to deal with all the languages files correctly.

If you are interested in the features, but need some changes, feel free to request them or fix them yourself.