### PR TITLE
fix mini calendar sometime cannot disable day for hidden days

### DIFF
--- a/web/js/general.js.php
+++ b/web/js/general.js.php
@@ -165,6 +165,16 @@ $(document).on('page_ready', function() {
 
   <?php // Retrieve the data that the JavaScript files need. ?>
   args = $('body').data();
+  //  unresolved bug that sometime isBookAdmin is string 'false'/'true', apply workaround here    
+    if (typeof args.isBookAdmin=='string'){
+      if (args.isBookAdmin=='true') args.isBookAdmin=true;
+      if (args.isBookAdmin=='false') args.isBookAdmin=false;
+    }
+  //  unresolved bug that sometime isAdmin is string 'false'/'true', apply workaround here    
+    if (typeof args.isAdmin=='string'){
+      if (args.isAdmin=='true') args.isAdmin=true;
+      if (args.isAdmin=='false') args.isAdmin=false;
+    }
 
   <?php // Fire off the Ajax requests for username fields ?>
   fillUsernameFields();


### PR DESCRIPTION
At datepicker.js, it will disable the day for hidden days, depend on the js global args.isBookAdmin.  
But it always has the value of string 'false', instead of bool false.  
In the genernal.js It is wired that jQuery should get it from body data and auto convert to bool false, according to jQuery documentation, but it does not.  So I add it to force converting the type.  
https://github.com/meeting-room-booking-system/mrbs-code/blob/4f5a7136c8d0f1557f161fdd6f157ca9f195826a/web/js/datepicker.js.php#L115
![image](https://user-images.githubusercontent.com/17800518/177973738-70eb8bfa-e8a5-4848-b6bb-5c5056e0e147.png)



