### PR TITLE
Minicalendar range

### DIFF
--- a/web/js/datepicker.js.php
+++ b/web/js/datepicker.js.php
@@ -60,6 +60,7 @@ function getISODate(year, month, day)
 <?php
 // Functions to find the start and end dates of a week and month given a
 // date in YYYY-MM-DD format.
+// weekStarts is the start day of the week (0 for Sunday, 1 for Monday etc.)
 // (Could be implemented by extending the Date class, but extends isn't
 // supported by IE11.)
 ?>

--- a/web/js/datepicker.js.php
+++ b/web/js/datepicker.js.php
@@ -282,21 +282,37 @@ $(document).on('page_ready', function() {
 
         $.each(minicalendars, function (key, value) {
             var startDate, endDate;
-            if (args.view === 'month')
+            <?php
+            // Setting a range only works if there are no hidden days: it does not make
+            // sense to set a start date of a range on a disabled day.
+            if (empty($hidden_days))
             {
-              startDate = monthStart(args.pageDate);
-              endDate = monthEnd(args.pageDate);
-            }
-            else if (args.view === 'week')
-            {
-              startDate = weekStart(args.pageDate, <?php echo $weekstarts?>);
-              endDate = weekEnd(args.pageDate, <?php echo $weekstarts?>);
+              ?>
+              if (args.view === 'month')
+              {
+                startDate = monthStart(args.pageDate);
+                endDate = monthEnd(args.pageDate);
+              }
+              else if (args.view === 'week')
+              {
+                startDate = weekStart(args.pageDate, <?php echo $weekstarts?>);
+                endDate = weekEnd(args.pageDate, <?php echo $weekstarts?>);
+              }
+              else
+              {
+                startDate = args.pageDate;
+                endDate = startDate;
+              }
+              <?php
             }
             else
             {
+              ?>
               startDate = args.pageDate;
               endDate = startDate;
+              <?php
             }
+            ?>
             value.setDate([startDate, endDate]);
             value.changeMonth(key);
           });

--- a/web/js/datepicker.js.php
+++ b/web/js/datepicker.js.php
@@ -57,6 +57,24 @@ function getISODate(year, month, day)
     ].join('-');
 }
 
+<?php
+// Functions to find the start and end dates of a week and month given a
+// date in YYYY-MM-DD format.
+// (Could be implemented by extending the Date class, but extends isn't
+// supported by IE11.)
+?>
+
+function weekStart(date, weekStarts) {
+  var d = new Date(date);
+  d.setDate(d.getDate() - (d.getDay() - weekStarts));
+  return d.toISOString().split('T')[0];
+}
+
+function weekEnd(date, weekStarts) {
+  var d = new Date(weekStart(date, weekStarts));
+  d.setDate(d.getDate() + 6);
+  return d.toISOString().split('T')[0];
+}
 
 function monthStart(date) {
   var d = new Date(date);
@@ -71,17 +89,6 @@ function monthEnd(date) {
   return d.toISOString().split('T')[0];
 }
 
-function weekStart(date, weekStarts) {
-  var d = new Date(date);
-  d.setDate(d.getDate() - (d.getDay() - weekStarts));
-  return d.toISOString().split('T')[0];
-}
-
-function weekEnd(date, weekStarts) {
-  var d = new Date(weekStart(date, weekStarts));
-  d.setDate(d.getDate() + 6);
-  return d.toISOString().split('T')[0];
-}
 
 $(document).on('page_ready', function() {
 

--- a/web/js/datepicker.js.php
+++ b/web/js/datepicker.js.php
@@ -66,7 +66,12 @@ function getISODate(year, month, day)
 
 function weekStart(date, weekStarts) {
   var d = new Date(date);
-  d.setDate(d.getDate() - (d.getDay() - weekStarts));
+  var diff = d.getDay() - weekStarts;
+  if (diff < 0)
+  {
+    diff += 7;
+  }
+  d.setDate(d.getDate() - diff);
   return d.toISOString().split('T')[0];
 }
 

--- a/web/js/datepicker.js.php
+++ b/web/js/datepicker.js.php
@@ -58,6 +58,30 @@ function getISODate(year, month, day)
 }
 
 
+function monthStart(date) {
+  var d = new Date(date);
+  d.setDate(1);
+  return d.toISOString().split('T')[0];
+}
+
+function monthEnd(date) {
+  var d = new Date(date);
+  d.setMonth(d.getMonth() + 1);
+  d.setDate(0);
+  return d.toISOString().split('T')[0];
+}
+
+function weekStart(date, weekStarts) {
+  var d = new Date(date);
+  d.setDate(d.getDate() - (d.getDay() - weekStarts));
+  return d.toISOString().split('T')[0];
+}
+
+function weekEnd(date, weekStarts) {
+  var d = new Date(weekStart(date, weekStarts));
+  d.setDate(d.getDate() + 6);
+  return d.toISOString().split('T')[0];
+}
 
 $(document).on('page_ready', function() {
 
@@ -252,11 +276,28 @@ $(document).on('page_ready', function() {
         config.onMonthChange = onMonthChange;
         config.onYearChange = onYearChange;
         config.onChange = onMinicalChange;
+        config.mode = 'range';
 
         var minicalendars = flatpickr('span.minicalendar', config);
 
         $.each(minicalendars, function (key, value) {
-            value.setDate(args.pageDate);
+            var startDate, endDate;
+            if (args.view === 'month')
+            {
+              startDate = monthStart(args.pageDate);
+              endDate = monthEnd(args.pageDate);
+            }
+            else if (args.view === 'week')
+            {
+              startDate = weekStart(args.pageDate, <?php echo $weekstarts?>);
+              endDate = weekEnd(args.pageDate, <?php echo $weekstarts?>);
+            }
+            else
+            {
+              startDate = args.pageDate;
+              endDate = startDate;
+            }
+            value.setDate([startDate, endDate]);
             value.changeMonth(key);
           });
 


### PR DESCRIPTION
An alternative to [PR #53](https://github.com/meeting-room-booking-system/mrbs-code/pull/53) that avoids the use of the Moment library and also only uses ranges if there are no hidden days (in order to avoid a problem if the range starts on a hidden day).