### PR TITLE
Session moodle

### DIFF
--- a/web/auth/cms/moodle.inc
+++ b/web/auth/cms/moodle.inc
@@ -1,0 +1,12 @@
+<?php
+
+global $auth;
+
+$moodle_dir = realpath(MRBS_ROOT . '/' . $auth['moodle']['rel_path']);
+
+if ($moodle_dir === false)
+{
+  $message = MRBS_ROOT . '/' . $auth['moodle']['rel_path'] . ' does not exist.  Check the setting ' .
+             'of $auth["moodle"]["rel_path"] in your config file.';
+  die($message);  // Too early for fatal_error()
+}

--- a/web/lib/MRBS/Session/SessionMoodle.php
+++ b/web/lib/MRBS/Session/SessionMoodle.php
@@ -1,0 +1,113 @@
+<?php
+namespace MRBS\Session;
+
+use MRBS\User;
+use function MRBS\auth;
+use \context_coursecat;
+require_once MRBS_ROOT . '/auth/cms/moodle.inc'; //sets moodle_dir or dies
+
+require_once($moodle_dir . '/config.php');
+global $USER, $moodle_dir, $PAGE;
+require_login();
+class SessionMoodle extends SessionWithLogin
+{
+
+  // User is expected to already be authenticated by the web server, so do nothing
+  public function authGet(?string $target_url=null, ?string $returl=null, ?string $error=null, bool $raw=false) : void
+  {
+  }
+
+
+  public function getCurrentUser() : ?User
+  {
+    global $USER;
+    if ($USER->username === ''){
+      return null;
+  }
+    $moodle_user = $USER->username;
+
+
+    $user = new User($USER->username);
+    $user->display_name = $USER->firstname . ' ' . $USER->lastname;
+    $user->email = $USER->email;
+    $user->level = $this->getUserLevel($USER->username);
+    return $user;
+    //return auth()->getUser($user->username);
+  }
+
+
+  public function getLogonFormParams() : ?array
+  {
+    global $auth;
+
+    if (isset($auth['remote_user']['login_link']))
+    {
+      return array(
+          'action' => $auth['remote_user']['login_link'],
+          'method' => 'get'
+        );
+    }
+    else
+    {
+      return null;
+    }
+  }
+
+
+  public function getLogoffFormParams() : ?array
+  {
+    global $auth;
+    global $USER;
+
+    if (isset($auth['moodle_user']['logout_link']))
+    {
+      return array(
+          'action' => $auth['moodle_user']['logout_link'] . '?sesskey='. $USER->sesskey,
+          'method' => 'get'
+        );
+    }
+    else
+    {
+      return null;
+    }
+  }
+
+  private static function getUserLevel($username) : int
+  {
+    global $auth, $moodle_dir;
+    global $USER, $PAGE;
+
+    // User not logged in, user level '0'
+    /*if ($USER->guest)
+    {
+      return 0;
+    }*/
+
+    // Otherwise get the user's access levels
+
+    // Check if they have admin access
+    if (isset($auth['moodle']['admin_access_levels']))
+    {
+      $admin = $auth['moodle']['admin_access_levels'];
+      if ($USER->username === $admin)
+      {
+        return 2;
+      }
+    }
+
+    // Check if they have user access
+      //require_once $moodle_dir . '/lib/accesslib.php';
+        $context = $PAGE->context;
+      $instance = new \stdClass();
+      #$block_prenotazioni = context_block::instance( $auth['moodle']['blockid_teachers'] );
+      #if (has_capability('moodle/block:edit',  $block_prenotazioni))
+    $contextcoursecatID = $auth['moodle']['contextcoursecatID'];
+    $context = \context_coursecat::instance($contextcoursecatID);
+    if (has_capability('moodle/course:create', $context))
+      {
+        return 1;
+      }
+    // Everybody else is access level '0'
+    return 0;
+  }
+}

--- a/web/systemdefaults.inc.php
+++ b/web/systemdefaults.inc.php
@@ -962,7 +962,7 @@ $auth["type"] = "db"; // How to validate the user/password. One of
 
 $auth["session"] = "php"; // How to get and keep the user ID. One of
                           // "cas", "cookie", "host", "http", "ip", "joomla", "nt",
-                          // "omni", "php", "remote_user", "saml" or "wordpress".
+                          // "omni", "php", "remote_user", "saml", "wordpress" or "moodle".
 
 // Configuration parameters for 'cookie' session scheme
 
@@ -1041,6 +1041,16 @@ $auth["realm"]  = "mrbs";
 // 'session_remote_user' configuration settings
 //$auth['remote_user']['login_link'] = '/login/link.html';
 //$auth['remote_user']['logout_link'] = '/logout/link.html';
+
+// session "moodle" configuration settings
+// to be used  with auth="none" (the authentication is already done by moodle
+$auth['moodle']['rel_path'] = '..'; //MRBS should be in a subdirectory of moodle
+//If you want to display a logout link, set in config.inc.php:
+$auth['moodle']['logout_link'] = $auth['moodle']['rel_path'] . '/login/logout.php'; //param sesskey will be added automatically
+$auth["admin"][] = "admin";
+$auth["moodle"]["admin_access_levels"] = "admin";
+$auth['moodle']['contextcoursecatID'] = 2; //the id of the category in Moodle where teachers are allowed to create courses, i.e. moodle/course:create
+
 
 // 'auth_ext' configuration settings
 $auth["prog"]   = "";

--- a/web/systemdefaults.inc.php
+++ b/web/systemdefaults.inc.php
@@ -1049,7 +1049,7 @@ $auth['moodle']['rel_path'] = '..'; //MRBS should be in a subdirectory of moodle
 $auth['moodle']['logout_link'] = $auth['moodle']['rel_path'] . '/login/logout.php'; //param sesskey will be added automatically
 $auth["admin"][] = "admin";
 $auth["moodle"]["admin_access_levels"] = "admin";
-$auth['moodle']['contextcoursecatID'] = 2; //the id of the category in Moodle where teachers are allowed to create courses, i.e. moodle/course:create
+$auth['moodle']['contextcoursecatID'] = 2; //the id of the category in Moodle where teachers are allowed to create courses, i.e. moodle/course:create - those will get Auth level 1 in MRBS
 
 
 // 'auth_ext' configuration settings


### PR DESCRIPTION
Added the authentication through Moodle session on the model of remote user (auth = none because it is assumed that authentication is already managed by moodle itself). In order to easily get the moodle's session (i.e. without any modification in moodle) , MRBS should be in a subdirectory.
The users that have the capability to create courses in a specified category in moodle ("moodle/course:create") - tipically this is true for teachers - are granted an Access level = 1 (further adjustments on this can be done to meet the diverse installation requirements)