### PR TITLE
fix missing table in grant.pg.sql

### DIFF
--- a/grant.pg.sql
+++ b/grant.pg.sql
@@ -20,5 +20,6 @@ GRANT ALL ON
    mrbs_room,mrbs_room_id_seq,
    mrbs_users,mrbs_users_id_seq,
    mrbs_variables,mrbs_variables_id_seq,
+   mrbs_participants,mrbs_participants_id_seq,
    mrbs_zoneinfo,mrbs_zoneinfo_id_seq
 TO mrbs;


### PR DESCRIPTION
i always had problems after creating areas and rooms on systems installed with pgsql,
turns out the mrbs_participants table was missing from the grant.pg.sql

still wondering, why nobody had these problems in the last 6 years? (last commit of grant.pg.sql)