### PR TITLE
SAML Access Control Filter

### DIFF
--- a/AUTHENTICATION
+++ b/AUTHENTICATION
@@ -878,11 +878,14 @@ $auth['saml']['authsource'] = 'default-sp';
 $auth['saml']['attr']['username'] = 'sAMAccountName';
 $auth['saml']['attr']['mail'] = 'mail';
 $auth['saml']['admin']['memberOf'] = ['CN=Domain Admins,CN=Users,DC=example,DC=com'];
+// Optional access control filter
+$auth['saml']['user']['memberOf'] = ['CN=Calendar Users,CN=Users,DC=example,DC=com'];
 
-This scheme assumes that you've already configured SimpleSamlPhp,
-and that you have set up aliases in your webserver so that SimpleSamlPhp
-can handle incoming assertions.  Refer to the SimpleSamlPhp documentation
-for more information on how to do that.
+This scheme assumes that you've already configured SimpleSamlPhp, that
+you have configured oid2name mapping, and that you have set up aliases
+in your webserver so that SimpleSamlPhp can handle incoming assertions.
+Refer to the SimpleSamlPhp documentation for more information on how to
+do that.
 
 https://simplesamlphp.org/docs/stable/simplesamlphp-install
 https://simplesamlphp.org/docs/stable/simplesamlphp-sp

--- a/web/lib/MRBS/Auth/AuthSaml.php
+++ b/web/lib/MRBS/Auth/AuthSaml.php
@@ -101,6 +101,27 @@ class AuthSaml extends Auth
         }
       }
 
+      if (isset($auth['saml']['user'])
+      {
+        foreach ($auth['saml']['user'] as $attr => $values)
+        {
+          if (array_key_exists($attr, $userData))
+          {
+            foreach ($values as $value)
+            {
+              if (in_array($value, $userData[$attr]))
+              {
+                return 1;
+              }
+            }
+          }
+        }
+      }
+      else
+      {
+        return 1;
+      }
+
       return 1;
     }
 

--- a/web/systemdefaults.inc.php
+++ b/web/systemdefaults.inc.php
@@ -1355,6 +1355,8 @@ $auth['saml']['attr']['mail'] = 'mail';
 $auth['saml']['attr']['givenName'] = 'givenname';
 $auth['saml']['attr']['surname'] = 'sn';
 $auth['saml']['admin']['memberOf'] = ['CN=Domain Admins,CN=Users,DC=example,DC=com'];
+// Optional access control filter
+//$auth['saml']['user']['memberOf'] = ['CN=Calendar Admins,CN=Users,DC=example,DC=com'];
 // MRBS session initialisation can interfere with session handling in some
 // SAML libraries.  If so, set this to true.
 $auth['saml']['disable_mrbs_session_init'] = false;


### PR DESCRIPTION
I'm using MRBS with the University of Wisconsin-Madison's SAML2.0 SSO service. As a campus-wide service, it lets everybody affiliated with the campus access the calendar, which is obviously undesirable. I have added a little bit of code to the SAML code in MRBS to check whether a user has a particular attribute set in order to be able to use the calendar. I'm submitting this pull request in case the project maintainers would like to incorporate this feature into 'main'.