### PR TITLE
explicit int cast to be compatible with php8

### DIFF
--- a/web/edit_entry.php
+++ b/web/edit_entry.php
@@ -1628,7 +1628,7 @@ while (false !== ($row = $res->next_row_keyed()))
     $row['resolution'] = 60;
   }
   // Generate some derived settings
-  $row['max_duration_qty'] = $row['max_duration_secs'];
+  $row['max_duration_qty'] = intval($row['max_duration_secs']);
   toTimeString($row['max_duration_qty'], $row['max_duration_units']);
   // Get the start and end of the booking day
   if ($row['enable_periods'])


### PR DESCRIPTION
When deployed on a host with php 8.0.30, I encountered the following error:

```
Uncaught exception 'TypeError' in /var/www/html/mrbs/functions.inc at line 928
abs(): Argument #1 ($num) must be of type int|float, string given
#0 /var/www/html/mrbs/functions.inc(928): abs()
#1 /var/www/html/mrbs/edit_entry.php(1633): MRBS\toTimeString()
#2 {main}
```

By searching, it appears [php8 now requires explicit conversion](https://www.php.net/manual/en/function.abs.php) to int or float.

> Changelog
> 8.0.0 	no longer accepts internal objects which support numeric conversion. 
