### PR TITLE
Normalize encoding checks in mbstring functions gotten from PHPMailer

### DIFF
--- a/web/lib/MRBS/Mbstring/Mbstring.php
+++ b/web/lib/MRBS/Mbstring/Mbstring.php
@@ -80,7 +80,7 @@ class Mbstring
 
   public static function mb_chr(int $codepoint, ?string $encoding = null)
   {
-    if (isset($encoding) && ($encoding !== 'UTF-8'))
+    if (isset($encoding) && (strtoupper($encoding) !== 'UTF-8'))
     {
       $message = "This emulation of " . __FUNCTION__ . "() only supports the UTF-8 encoding.";
       throw new InvalidArgumentException($message);
@@ -111,7 +111,7 @@ class Mbstring
 
   public static function mb_ord(string $string, ?string $encoding=null)
   {
-    if (isset($encoding) && ($encoding !== 'UTF-8'))
+    if (isset($encoding) && (strtoupper($encoding) !== 'UTF-8'))
     {
       $message = "This emulation of " . __FUNCTION__ . "() only supports the UTF-8 encoding.";
       throw new InvalidArgumentException($message);
@@ -167,7 +167,7 @@ class Mbstring
 
   public static function mb_stripos(string $haystack, string $needle, int $offset=0, ?string $encoding=null)
   {
-    if (isset($encoding) && ($encoding !== 'UTF-8'))
+    if (isset($encoding) && (strtoupper($encoding) !== 'UTF-8'))
     {
       $message = "This emulation of " . __FUNCTION__ . "() only supports the UTF-8 encoding.";
       throw new InvalidArgumentException($message);
@@ -182,7 +182,7 @@ class Mbstring
 
   public static function mb_strpos(string $haystack, string $needle, int $offset=0, ?string $encoding=null)
   {
-    if (isset($encoding) && ($encoding !== 'UTF-8'))
+    if (isset($encoding) && (strtoupper($encoding) !== 'UTF-8'))
     {
       $message = "This emulation of " . __FUNCTION__ . "() only supports the UTF-8 encoding.";
       throw new InvalidArgumentException($message);
@@ -194,7 +194,7 @@ class Mbstring
 
   public static function mb_strripos(string $haystack, string $needle, int $offset=0, ?string $encoding=null)
   {
-    if (isset($encoding) && ($encoding !== 'UTF-8'))
+    if (isset($encoding) && (strtoupper($encoding) !== 'UTF-8'))
     {
       $message = "This emulation of " . __FUNCTION__ . "() only supports the UTF-8 encoding.";
       throw new InvalidArgumentException($message);
@@ -206,7 +206,7 @@ class Mbstring
 
   public static function mb_strrpos(string $haystack, string $needle, int $offset=0, ?string $encoding=null)
   {
-    if (isset($encoding) && ($encoding !== 'UTF-8'))
+    if (isset($encoding) && (strtoupper($encoding) !== 'UTF-8'))
     {
       $message = "This emulation of " . __FUNCTION__ . "() only supports the UTF-8 encoding.";
       throw new InvalidArgumentException($message);
@@ -227,6 +227,7 @@ class Mbstring
     {
       case null:
       case 'UTF-8':
+      case 'utf-8':
         $result = count((new Utf8String($string))->toArray());
         break;
       case '8bit':
@@ -248,7 +249,7 @@ class Mbstring
       return $string;
     }
 
-    if (isset($encoding) && ($encoding !== 'UTF-8'))
+    if (isset($encoding) && (strtoupper($encoding) !== 'UTF-8'))
     {
       $message = "This emulation of " . __FUNCTION__ . "() only supports the UTF-8 encoding.";
       throw new InvalidArgumentException($message);
@@ -274,7 +275,7 @@ class Mbstring
       return $string;
     }
 
-    if (isset($encoding) && ($encoding !== 'UTF-8'))
+    if (isset($encoding) && (strtoupper($encoding) !== 'UTF-8'))
     {
       $message = "This emulation of " . __FUNCTION__ . "() only supports the UTF-8 encoding.";
       throw new InvalidArgumentException($message);
@@ -295,7 +296,7 @@ class Mbstring
 
   public static function mb_substr(string $string, int $start, ?int $length = null, ?string $encoding = null): string
   {
-    if (isset($encoding) && ($encoding !== 'UTF-8'))
+    if (isset($encoding) && (strtoupper($encoding) !== 'UTF-8'))
     {
       $message = "This emulation of " . __FUNCTION__ . "() only supports the UTF-8 encoding.";
       throw new InvalidArgumentException($message);


### PR DESCRIPTION
I encountered the following in Chinese browers when submit new entries with CJK character.

The problem might be in ```get_charset()``` and ```get_mail_charset()``` function in [language.inc](https://github.com/meeting-room-booking-system/mrbs-code/blob/54100f7412a3d814d7068b3bf2876682a146fd3e/web/language.inc#L654). It returns ```PHPMailer::CHARSET_UTF8``` which is ```'utf-8'``` (lowercase), but the MRBS Mbstring class only accepts ```'UTF-8'``` (uppercase).

```
Uncaught exception 'InvalidArgumentException' in /var/www/html/mrbs/lib/MRBS/Mbstring/Mbstring.php at line 236
Encoding 'utf-8' is not supported.
#0 /var/www/html/mrbs/functions_global.inc(48): MRBS\Mbstring\Mbstring::mb_strlen()
#1 /var/www/html/mrbs/lib/PHPMailer/src/PHPMailer.php(3684): mb_strlen()
#2 /var/www/html/mrbs/lib/PHPMailer/src/PHPMailer.php(3650): PHPMailer\PHPMailer\PHPMailer->hasMultiBytes()
#3 /var/www/html/mrbs/lib/PHPMailer/src/PHPMailer.php(2546): PHPMailer\PHPMailer\PHPMailer->encodeHeader()
#4 /var/www/html/mrbs/lib/MRBS/User.php(113): PHPMailer\PHPMailer\PHPMailer->addrFormat()
#5 /var/www/html/mrbs/functions_mail.inc(744): MRBS\User->mailbox()
#6 /var/www/html/mrbs/functions_mail.inc(873): MRBS\create_addresses()
#7 /var/www/html/mrbs/mrbs_sql.inc(2853): MRBS\notifyAdminOnBooking()
#8 /var/www/html/mrbs/edit_entry_handler.php(809): MRBS\mrbsMakeBookings()
#9 {main}

MRBS GET: Array
(
)
MRBS POST: Array
(
    [MAX_FILE_SIZE] => 2097152
    [csrf_token] => dea6d6deffb95fcfa1204610b9bf21c95ffe802d7b46d5a4bfd6dfc20cea9850
    [returl] => /index.php?view=day&page_date=2025-07-10&area=1&room=4
    [rep_id] => 0
    [edit_series] => 0
    [top] => 0
    [create_by] => junsenlao
    [name] => MUST meeting
    [description] =>
    [start_date] => 2025-07-10
    [start_seconds] => 50400
    [end_date] => 2025-07-10
    [end_seconds] => 57600
    [area] => 1
    [rooms] => Array
        (
            [0] => 4
        )

    [type] => I
    [confirmed] => 1
    [rep_type] => 0
    [rep_day] => Array
        (
            [0] => 4
        )

    [month_type] => 0
    [month_absolute] => 10
    [month_relative_ord] => 2
    [month_relative_day] => TH
    [rep_interval] => 1
    [rep_end_date] => 2025-07-10
)
```