### PR TITLE
Feature: Prevent admin from skipping booking policies

### DIFF
--- a/web/mrbs_sql.inc
+++ b/web/mrbs_sql.inc
@@ -476,7 +476,7 @@ function mrbsCheckPolicy(array $booking, ?int $ignore_entry_id=null, ?int $ignor
   global $prevent_simultaneous_bookings, $prevent_invalid_types, $invalid_types_days;
   global $prevent_booking_on_holidays, $prevent_booking_on_weekends;
   global $periods_booking_opens, $measure_max_to_start_time;
-  global $prevent_admin_skip_policies;
+  global $auth;
 
   $result = array('notices' => array(),
                   'errors'  => array());
@@ -485,7 +485,7 @@ function mrbsCheckPolicy(array $booking, ?int $ignore_entry_id=null, ?int $ignor
 
   // If the user is a booking admin for this room then we still check for policy
   // violations, but they are for information only and are classed as 'notices'
-  $violation_status = (is_book_admin($booking['room_id']) && !$prevent_admin_skip_policies) ? 'notices' : 'errors';
+  $violation_status = (is_book_admin($booking['room_id']) && !$auth['admin_must_obey_policies']) ? 'notices' : 'errors';
 
   $now = time();
   if ($enable_periods)

--- a/web/systemdefaults.inc.php
+++ b/web/systemdefaults.inc.php
@@ -415,8 +415,6 @@ $prevent_booking_on_holidays = true;
 // Set this to true to prevent bookings being made on weekends (see $weekdays).
 $prevent_booking_on_weekends = false;
 
-// Set this to true to prevent admins from skipping booking policies.
-$prevent_admin_skip_policies = false;
 
 /******************
  * Display settings
@@ -1621,6 +1619,9 @@ $auth['users_can_delete_others_registrations'] = false;
 // Set this to true if you don't want admins to be able to make bookings
 // on behalf of other users
 $auth['admin_can_only_book_for_self'] = false;
+
+// Set this to true to prevent admins from skipping booking policies.
+$auth['admin_must_obey_policies'] = false;
 
 // An array of booking types for admin use only
 $auth['admin_only_types'] = array();  // eg array('E');


### PR DESCRIPTION
* Add new option: prevent_admin_skip_policies 
Default value is false, current behaviour remains unchanged

Hello,
I would like to introduce a new option. When this option is enabled, administrators and regular users must comply with the booking policy.
Best regards, Fabian