### PR TITLE
admin.php: Use area of change-area form for add-room form

### DIFF
--- a/web/admin.php
+++ b/web/admin.php
@@ -72,10 +72,25 @@ function generate_area_change_form(array $enabled_areas, array $disabled_areas) 
   {
     $options = array(get_vocab("enabled") => $enabled_areas,
                      get_vocab("disabled") => $disabled_areas);
+    if (empty($area))
+    {
+      foreach ($options as $current_areas)
+      {
+        if (!empty($current_areas))
+        {
+          $area = array_key_first($current_areas);
+          break;
+        }
+      }
+    }
   }
   else
   {
     $options = $enabled_areas;
+    if (empty($area) && !empty($options))
+    {
+      $area = array_key_first($options);
+    }
   }
 
   $field = new FieldSelect();


### PR DESCRIPTION
If you create one or more empty areas in an empty database and go to `/admin.php` with no query parameters (e.g., in a new browser tab), then the first area is rendered, but you can't create rooms in it.

More formally, here's a Codeception test (WebDriver, Firefox) that fails:
```php
run('psql -v ON_ERROR_STOP=1 -X -q -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"');
run('psql -v ON_ERROR_STOP=1 -X -q -f .../mrbs-code/tables.pg.sql');

$I->amOnPage('/');
createUser($I, USERNAME_ADMIN, PASSWORD_ADMIN, 'Test Admin');
$I->fillField('User', USERNAME_ADMIN);
$I->fillField('Password', PASSWORD_ADMIN);
$I->click('Log in');

$I->click('Rooms');
$I->fillField('Name', 'Test Area');
$I->click('Add Area');

// Optionally:
$I->click('button[title="Edit"]');
$I->selectOption('input[name="area_disabled"]', '1'); 
$I->click('Save');

$I->amOnPage('/admin.php'); // resets `area`

$I->fillField('#room_name', 'Test Room'); // fails: no `#room_name`
$I->click('Add Room');
```

Reason: the add-room form is rendered only when `$area` (in `admin.php`) is not empty. `$area` is taken from request parameters if present (e.g., after editing an area); otherwise it comes from `get_default_area()`. However, `get_default_area()` considers neither empty areas (despite its description; I'll open a PR for that) nor disabled areas.

I fixed this by setting `$area` in `generate_area_change_form()`. Now `$area` used for the add-room form matches the area selected in the change-area form.
