### PR TITLE
Align `get_default_area()` description and implementation for empty areas

### DIFF
--- a/web/functions.inc
+++ b/web/functions.inc
@@ -1430,9 +1430,10 @@ function escape_js(string $str) : string
 }
 
 
-// Return a default area; used if no area is already known. This returns the
-// area that contains the default room (if it is set, valid and enabled) otherwise the
-// first area in alphabetical order in the database (no guarantee there is an area 1).
+// Return a default area; used if no area is already known. Preference order:
+// - the area that contains the default room (if it is set, valid, and enabled)
+// - the first enabled area that contains an enabled, visible room
+// - the first enabled area (if enabled areas exist)
 // The area must be enabled for it to be considered.
 // This could be changed to implement something like per-user defaults.
 function get_default_area() : int
@@ -1488,6 +1489,20 @@ function get_default_area() : int
     {
       return (int) $row['area_id'];
     }
+  }
+
+  // If there are enabled areas, return the first enabled area
+  $sql = "SELECT id FROM " . _tbl('area');
+  if ($disabled_field_exists)
+  {
+    $sql .= " WHERE disabled = 0";
+  }
+  $sql .= " ORDER BY $order_by_column LIMIT 1";
+  $area = db()->query1($sql);
+
+  if ($area > 0)
+  {
+    return $area;
   }
 
   return 0;


### PR DESCRIPTION
This was my first attempt to fix the bug described in #3969. I’m not sure if this is the intended way to align the description and the implementation, but it should avoid edge cases like the one in #3969.