### PR TITLE
fix docker dev environment

### DIFF
--- a/docker_app/HOWTO.md
+++ b/docker_app/HOWTO.md
@@ -1,4 +1,4 @@
-# Dev environment 
+# Dev environment
 
 This docker setup is supposed to get a running system for local development.
 
@@ -6,8 +6,8 @@ This docker setup is supposed to get a running system for local development.
 
 * Compose Docker containers:
   ~~~
-  cd docker_app 
-  docker-compose up -d
+  cd docker_app
+  docker compose up -d
   ~~~
   (Linux users may need `sudo` or `docker login`)
 
@@ -29,11 +29,11 @@ docker-compose db mysql -u mrbs -pmrbs mrbs
 
 View apache webserver logs:
 ~~~
-docker-compose logs www
+docker compose logs www
 ~~~
 View database logs:
 ~~~
-docker-compose logs db
+docker compose logs db
 ~~~
 
 
@@ -46,7 +46,7 @@ However, when configuration of php and database is change, you have to reset the
 
 * Stop Docker containers:
   ~~~
-  docker-compose down
+  docker compose down
   ~~~
 * Delete persisted volumes:
   ~~~
@@ -54,6 +54,6 @@ However, when configuration of php and database is change, you have to reset the
   ~~~
 * Rebuild container images:
   ~~~
-  docker-compose build
+  docker compose build
   ~~~
 

--- a/docker_app/docker-compose.yml
+++ b/docker_app/docker-compose.yml
@@ -1,11 +1,11 @@
-version: "3.1"
 services:
     www:
         build:
             context: ..
             dockerfile: docker_app/php/Dockerfile
-        ports: 
+        ports:
             - "8080:80"
+        command: apache2ctl -D FOREGROUND
         volumes:
             - ../web:/var/www/html/
             - ./php/config.inc.php:/var/www/html/config.inc.php
@@ -15,11 +15,11 @@ services:
             - default
     db:
         image: mysql:8.0
-        ports: 
+        ports:
             - "3306:3306"
         command: --default-authentication-plugin=mysql_native_password
         environment:
-            MYSQL_DATABASE: mrbs 
+            MYSQL_DATABASE: mrbs
             MYSQL_USER: mrbs
             MYSQL_PASSWORD: mrbs
             MYSQL_ROOT_PASSWORD: mrbs
@@ -30,7 +30,7 @@ services:
             - default
     phpmyadmin:
         image: phpmyadmin
-        links: 
+        links:
             - db:db
         ports:
             - 8888:80

--- a/docker_app/php/Dockerfile
+++ b/docker_app/php/Dockerfile
@@ -1,5 +1,6 @@
-FROM php:7.3-apache
+FROM php:8.4-apache
 
 RUN a2enmod rewrite
-RUN apt-get update && apt-get install -y locales-all
-RUN docker-php-ext-install mysqli pdo pdo_mysql 
+RUN apt-get update && apt-get install -y libicu-dev locales-all \
+ && apt-get clean
+RUN docker-php-ext-install mysqli pdo pdo_mysql intl


### PR DESCRIPTION
While working on #3982 I noticed the docker environment in `docker_app` didn't work anymore.

This commit fixes it: 

  * Update base image to php:8.4-apache
  * Update dependencies
  * Add "command" to docker-compose
  * Adjust README to modern docker