### PR TITLE
Add option to define fields as mandatory for specific areas

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -251,6 +251,15 @@ would define the 'conference_facilities' custom field to be mandatory.
 In the case of a select field, this adds an empty value to the dropdown
 list.
 
+If you want the field to be mandatory only for specific areas, you can instead
+set the value to an array of area IDs. For example:
+
+$is_mandatory_field['entry.conference_facilities'] = [1, 3];
+
+would define the 'conference_facilities' custom field to be mandatory only
+for the areas with ID 1 and 3. For other areas the field will exist but not
+be mandatory.
+
 Making a checkbox field mandatory is possible and requires the
 checkbox to be ticked before the form can be submitted.   This can be
 useful for example for requiring users to accept terms of service or

--- a/web/edit_entry.php
+++ b/web/edit_entry.php
@@ -134,10 +134,8 @@ function get_field_name(string $value, bool $disabled=false) : Field
 }
 
 
-function get_field_description(string $value, bool $disabled=false) : Field
+function get_field_description(string $value, array $is_mandatory_field, bool $disabled=false) : Field
 {
-  global $is_mandatory_field;
-
   $params = array('label'    => get_vocab('fulldescription'),
                   'name'     => 'description',
                   'field'    => 'entry.description',
@@ -492,10 +490,8 @@ function get_field_rooms($value, bool $disabled=false) : FieldSelect
 }
 
 
-function get_field_type(string $value, bool $disabled=false) : ?FieldSelect
+function get_field_type(string $value, array $is_mandatory_field, bool $disabled=false) : ?FieldSelect
 {
-  global $is_mandatory_field;
-
   // Get the options
   $options = get_type_options(is_book_admin());
 
@@ -573,10 +569,9 @@ function get_field_privacy_status(bool $value, bool $disabled=false) : ?FieldInp
 }
 
 
-function get_field_custom(string $key, bool $disabled=false)
+function get_field_custom(string $key, array $is_mandatory_field, bool $disabled=false)
 {
   global $custom_fields, $custom_fields_map;
-  global $is_mandatory_field;
 
   // TODO: have a common way of generating custom fields for all tables
 
@@ -1741,6 +1736,26 @@ if(isset($id) && !$copy)
 $fieldset = new ElementFieldset();
 $fieldset->addLegend(get_vocab($token));
 
+// Process the $is_mandatory_field configuration to work out which fields are mandatory for this area.
+// $is_mandatory_field can be a boolean or an array of area ids, so we need to process it to get a simple boolean for each field.
+$is_mandatory_field_processed = array();
+foreach ($is_mandatory_field as $key => $value)
+{
+  // Boolean values apply to all areas
+  if (is_bool($value))
+  {
+    $is_mandatory_field_processed[$key] = $value;
+  // Arrays of area_ids (ints) define the areas for which the field is mandatory
+  } elseif (in_array($area_id, $value))
+  {
+    $is_mandatory_field_processed[$key] = true;
+  } else
+  {
+    $is_mandatory_field_processed[$key] = false;
+
+  }
+}
+
 foreach ($edit_entry_field_order as $key)
 {
   switch ($key)
@@ -1764,7 +1779,7 @@ foreach ($edit_entry_field_order as $key)
       break;
 
     case 'description':
-      $fieldset->addElement(get_field_description($description));
+      $fieldset->addElement(get_field_description($description, $is_mandatory_field_processed));
       break;
 
     case 'start_time':
@@ -1781,7 +1796,7 @@ foreach ($edit_entry_field_order as $key)
       break;
 
     case 'type':
-      $fieldset->addElement(get_field_type($type));
+      $fieldset->addElement(get_field_type($type, $is_mandatory_field_processed));
       break;
 
     case 'confirmation_status':
@@ -1793,7 +1808,7 @@ foreach ($edit_entry_field_order as $key)
       break;
 
     default:
-      $fieldset->addElement(get_field_custom($key));
+      $fieldset->addElement(get_field_custom($key, $is_mandatory_field_processed));
       break;
 
   } // switch

--- a/web/js/edit_entry.js.php
+++ b/web/js/edit_entry.js.php
@@ -1443,6 +1443,30 @@ $(document).on('page_ready', function() {
           <?php // Switch end time select ?>
           reloadSlotSelector($('#end_seconds'), newArea);
 
+          <?php
+          // For each field which is only mandatory for some areas (i.e. the $is_mandatory_field entry for the field is an array)
+          // check whether the new area is in the array, and if so add the required attribute, otherwise remove it.
+          foreach ($is_mandatory_field as $key => $value)
+          {
+            list($table, $fieldname) = explode('.', $key, 2);
+            if ($table === 'entry') {
+              if (is_array($value))
+              {
+                ?>
+                var input_field = $('#f_<?php echo $fieldname ?>');
+                if ($.inArray(parseInt(newArea), <?php echo json_encode($value) ?>) >= 0) {
+                  input_field.prop('required', true);
+                } else {
+                  input_field.prop('required', false);
+                  input_field[0].setCustomValidity('');
+                }
+                input_field[0].checkValidity();
+                <?php
+              }
+            }
+          }
+          ?>
+
           adjustSlotSelectors();
         });
 


### PR DESCRIPTION
This adds the option to define fields as mandatory for specific areas only as discussed in #3982. It is fully backwards compatible with existing configurations.

From the updated docs:

```
If you want the field to be mandatory only for specific areas, you can instead
set the value to an array of area IDs. For example:

$is_mandatory_field['entry.conference_facilities'] = [1, 3];

would define the 'conference_facilities' custom field to be mandatory only
for the areas with ID 1 and 3. For other areas the field will exist but not
be mandatory.
```

There is code in `edit_entry_handler.php` that does something with `$is_mandatory_field`, but since the feature seems to work with the changes I did to the other file, I didn't touch it. Is this a potential issue?