### PR TITLE
Fix LDAP authentication failure on non-AD servers when using bind/search DN

### DIFF
--- a/web/lib/MRBS/Auth/AuthLdap.php
+++ b/web/lib/MRBS/Auth/AuthLdap.php
@@ -381,7 +381,7 @@ class AuthLdap extends Auth
     $res = @ldap_read(
         $ldap,
         $dn,
-        "(objectclass=*)",
+        "($user_search)",
         array_values($attributes),
         0,
         1
@@ -761,7 +761,7 @@ class AuthLdap extends Auth
               {
                 $entries = ldap_get_entries($ldap, $res);
                 $dn = $entries[0]["dn"];
-                $user_search = "distinguishedName=" . $dn;
+                $user_search = self::$all_ldap_opts['ldap_user_attrib'][$idx] . "=" . $username;
                 self::debug("found one entry dn '$dn'");
               }
               else


### PR DESCRIPTION
## Description
This PR fixes a bug in `AuthLdap.php` that causes user authentication to fail with `0 entries found` on
standard-compliant LDAP servers (such as OpenLDAP or 389 Directory Server) when a specific bind/service
user (`$ldap_dn_search_attrib`) is configured.

### The Problem
In the `action()` method (around line 764), when a unique user DN is successfully resolved using the
search/bind DN, MRBS hardcodes the fallback filter for the subsequent user property lookup
(`getUserCallback`) to Microsoft Active Directory syntax:
```php
$user_search = "distinguishedName=" . $dn;
```
While Active Directory handles queries against the `distinguishedName` attribute natively, RFC-compliant
LDAP servers do not feature this attribute or index. As a result, when `getUserCallback()` performs the
`ldap_read()` using `(distinguishedName=uid=...)`, the server returns `0 entries found`, causing the
entire login process to abort.

Furthermore, `getUserCallback()` hardcodes `(objectclass=*)` as the read filter, which is frequently
blocked or rejected by strict Access Control Lists (ACLs) on corporate or university LDAP directory
servers when queried via a service account.

### The Solution
Instead of forcing a proprietary Active Directory attribute, this change dynamically leverages the
already configured `$ldap_user_attrib` (e.g., `uid`, `mail`, or `cn`) and pairs it with
the resolved username:
```php
$user_search = self::$all_ldap_opts['ldap_user_attrib'][$idx] . "=" . $username;
```
### Benefits
* **Standard Compliance:** Fixes instant login failures on standard OpenLDAP, FreeIPA and 389-DS
environments.
* **Dynamic & Backward Compatible:** Automatically falls back to whatever attribute the administrator
defined in `config.inc.php`. This keeps existing Active Directory setups (using `sAMAccountName`)
perfectly intact while opening up full support for standard LDAP schemas.