### PR TITLE
Fix Gmail address lookup on PostgreSQL

### DIFF
--- a/web/lib/MRBS/Auth/AuthDb.php
+++ b/web/lib/MRBS/Auth/AuthDb.php
@@ -738,9 +738,10 @@ class AuthDb extends AuthDbAbstract
       elseif (in_array(mb_strtolower($address['domain']), array('gmail.com', 'googlemail.com')))
       {
         $sql_params = array(str_replace('.', '', $address['local']));
-        $sql_params[] = $sql_params[0];
-        $condition = "(LOWER(?) = REPLACE(TRIM(TRAILING '@gmail.com' FROM LOWER(email)), '.', '')) OR " .
-                     "(LOWER(?) = REPLACE(TRIM(TRAILING '@googlemail.com' FROM LOWER(email)), '.', ''))";
+        $local_part = $this->connection()->syntax_simple_split('email', '@', 1, $sql_params);
+        $domain = $this->connection()->syntax_simple_split('email', '@', 2, $sql_params);
+        $condition = "(LOWER(?) = REPLACE(LOWER($local_part), '.', '')) AND " .
+                     "(LOWER($domain) IN ('gmail.com', 'googlemail.com'))";
       }
       // Everything else: check the complete email address
       else


### PR DESCRIPTION
## Summary

- use the existing database split abstraction instead of backend-specific `TRIM` suffix behavior
- preserve case-insensitive, dot-insensitive Gmail and Googlemail aliases
- restrict normalized matches to Gmail and Googlemail domains

Fixes #4022

## Testing

- `php -l web/lib/MRBS/Auth/AuthDb.php`
- exercised `AuthDb::getUsersByEmail()` against PostgreSQL 16.14 and MariaDB 12.3.2 with Gmail, Googlemail, case/dot normalization, unrelated-domain, and no-match cases
- `git diff --check`
