### PR TITLE
Fix Git revision display in version information

### DIFF
--- a/test/test_version_git.php
+++ b/test/test_version_git.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+namespace MRBS;
+
+use RuntimeException;
+
+define('MRBS_ROOT', realpath(__DIR__ . '/../web'));
+
+function function_disabled(string $name) : bool
+{
+  return false;
+}
+
+$git_command = 'git';
+
+require_once MRBS_ROOT . '/version.inc';
+
+$expected_branch = exec(
+  escapeshellarg($git_command) . ' -C ' . escapeshellarg(MRBS_ROOT) .
+  ' rev-parse --abbrev-ref HEAD'
+);
+$expected_commit = exec(
+  escapeshellarg($git_command) . ' -C ' . escapeshellarg(MRBS_ROOT) .
+  ' rev-parse --short HEAD'
+);
+$actual = get_mrbs_version();
+$expected_suffix = "+git ($expected_branch $expected_commit)";
+
+if (!str_ends_with($actual, $expected_suffix))
+{
+  throw new RuntimeException(
+    "Expected version suffix '$expected_suffix', got '$actual'."
+  );
+}
+
+echo "$actual\n";

--- a/web/version.inc
+++ b/web/version.inc
@@ -16,12 +16,15 @@ function get_mrbs_version() : string
 
   if (function_exists('exec') && !function_disabled('exec'))
   {
+    $git_executable = escapeshellarg($git_command);
+    $git_work_tree = escapeshellarg(MRBS_ROOT);
+
     // Suppress any errors because we are only interested in success
-    $git_out = @exec("$git_command git rev-parse --abbrev-ref HEAD", $output, $retval);
+    $git_out = @exec("$git_executable -C $git_work_tree rev-parse --abbrev-ref HEAD", $output, $retval);
 
     if (($retval == 0) && (strlen($git_out)))
     {
-      $git_out2 = @exec("$git_command git rev-parse --short HEAD", $output, $retval);
+      $git_out2 = @exec("$git_executable -C $git_work_tree rev-parse --short HEAD", $output, $retval);
 
       if (($retval == 0) && (strlen($git_out2)))
       {


### PR DESCRIPTION
Fix `get_mrbs_version()` so installations running from a Git checkout correctly include the branch name and short commit hash, for example:

  `MRBS 1.12.2+git (fix/git_version ce91c601f)`

The previous command included an extra `git` argument and failed silently, so the Help page displayed only the base MRBS version.

## Changes

- Run the configured Git executable with the correct arguments.
- Use `git -C MRBS_ROOT` so revision detection does not depend on the current working directory.
- Shell-escape the Git executable and repository path.
- Add a regression test that verifies the generated version suffix.

## Testing

- `php test/test_version_git.php`
- `php -l web/version.inc`
- `php -l test/test_version_git.php`