### PR TITLE
Fix PHP compatibility errors in File_Passwd

### DIFF
--- a/web/File/Passwd.php
+++ b/web/File/Passwd.php
@@ -3,8 +3,8 @@
 
 /**
  * File::Passwd
- * 
- * PHP versions 4 and 5
+ *
+ * PHP versions 8
  *
  * LICENSE: This source file is subject to version 3.0 of the PHP license
  * that is available through the world-wide-web at the following URI:
@@ -97,17 +97,17 @@ $GLOBALS['_FILE_PASSWD_64'] =
     './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
 /**
-* The package File_Passwd provides classes and methods 
+* The package File_Passwd provides classes and methods
 * to handle many different kinds of passwd files.
-* 
-* The File_Passwd class in certain is a factory container for its special 
+*
+* The File_Passwd class in certain is a factory container for its special
 * purpose extension classes, each handling a specific passwd file format.
 * It also provides a static method for reasonable fast user authentication.
 * Beside that it offers some encryption methods used by the extensions.
 *
 * @author       Michael Wallner <mike@php.net>
 * @version      $Revision$
-* 
+*
 * Usage Example:
 * <code>
 *  $passwd = &File_Passwd::factory('Unix');
@@ -157,7 +157,7 @@ class File_Passwd
     {
         return $plain;
     }
-    
+
     /**
     * DES encryption
     *
@@ -172,7 +172,7 @@ class File_Passwd
         (is_null($salt) || strlen($salt) < 2) && $salt = File_Passwd::salt(2);
         return crypt($plain, $salt);
     }
-    
+
     /**
     * MD5 encryption
     *
@@ -180,26 +180,26 @@ class File_Passwd
     * @access   public
     * @return   string  crypted text
     * @param    string  $plain  plaintext to encrypt
-    * @param    string  $salt   the salt to use for encryption 
+    * @param    string  $salt   the salt to use for encryption
     *                           (>2 chars starting with $1$)
     */
     function crypt_md5($plain, $salt = null)
     {
         if (
-            is_null($salt) || 
-            strlen($salt) < 3 || 
+            is_null($salt) ||
+            strlen($salt) < 3 ||
             !preg_match('/^\$1\$/', $salt))
         {
             $salt = '$1$' . File_Passwd::salt(8);
         }
         return crypt($plain, $salt);
     }
-    
+
     /**
     * SHA1 encryption
     *
     * Returns a PEAR_Error if sha1() is not available (PHP<4.3).
-    * 
+    *
     * @static
     * @throws   PEAR_Error
     * @access   public
@@ -218,7 +218,7 @@ class File_Passwd
         return '{SHA}' . base64_encode($hash);
 
     }
-        
+
     /**
     * APR compatible MD5 encryption
     *
@@ -236,25 +236,25 @@ class File_Passwd
         } else {
             $salt = substr($salt, 0,8);
         }
-        
+
         $length  = strlen($plain);
         $context = $plain . '$apr1$' . $salt;
-        
+
         if (PEAR_ZE2) {
             $binary = md5($plain . $salt . $plain, true);
         } else {
             $binary = pack('H32', md5($plain . $salt . $plain));
         }
-        
+
         for ($i = $length; $i > 0; $i -= 16) {
             $context .= substr($binary, 0, min(16 , $i));
         }
         for ( $i = $length; $i > 0; $i >>= 1) {
             $context .= ($i & 1) ? chr(0) : $plain[0];
         }
-        
+
         $binary = PEAR_ZE2 ? md5($context, true) : pack('H32', md5($context));
-        
+
         for ($i = 0; $i < 1000; $i++) {
             $new = ($i & 1) ? $plain : $binary;
             if ($i % 3) {
@@ -266,7 +266,7 @@ class File_Passwd
             $new .= ($i & 1) ? $binary : $plain;
             $binary = PEAR_ZE2 ? md5($new, true) : pack('H32', md5($new));
         }
-        
+
         $p = array();
         for ($i = 0; $i < 5; $i++) {
             $k = $i + 6;
@@ -281,9 +281,9 @@ class File_Passwd
                 5
             );
         }
-        
-        return 
-            '$apr1$' . $salt . '$' . implode($p) . 
+
+        return
+            '$apr1$' . $salt . '$' . implode($p) .
             File_Passwd::_64(ord($binary[11]), 3);
     }
 
@@ -300,11 +300,11 @@ class File_Passwd
         $rs = '';
         $ln = strlen($hex);
         for($i = 0; $i < $ln; $i += 2) {
-            $rs .= chr(hexdec($hex{$i} . $hex{$i+1}));
+            $rs .= chr(hexdec($hex[$i] . $hex[$i+1]));
         }
         return $rs;
     }
-    
+
     /**
     * Convert to allowed 64 characters for encryption
     *
@@ -326,18 +326,18 @@ class File_Passwd
 
     /**
     * Factory for new extensions
-    * 
+    *
     * o Unix        for standard Unix passwd files
     * o CVS         for CVS pserver passwd files
     * o SMB         for SMB server passwd files
     * o Authbasic   for AuthUserFiles
     * o Authdigest  for AuthDigestFiles
     * o Custom      for custom formatted passwd files
-    * 
+    *
     * Returns a PEAR_Error if the desired class/file couldn't be loaded.
-    * 
+    *
     * @static   use &File_Passwd::factory() for instantiating your passwd object
-    * 
+    *
     * @throws   PEAR_Error
     * @access   public
     * @return   object    File_Passwd_$class - desired Passwd object
@@ -355,15 +355,15 @@ class File_Passwd
         }
         return new $class();
     }
-    
+
     /**
     * Fast authentication of a certain user
-    * 
+    *
     * Though this approach should be reasonable fast, it is NOT
     * with APR compatible MD5 encryption used for htpasswd style
     * password files encrypted in MD5. Generating one MD5 password
     * takes about 0.3 seconds!
-    * 
+    *
     * Returns a PEAR_Error if:
     *   o file doesn't exist
     *   o file couldn't be opened in read mode
@@ -372,7 +372,7 @@ class File_Passwd
     *   o file couldn't be closed (only if auth fails)
     *   o invalid <var>$type</var> was provided
     *   o invalid <var>$opt</var> was provided
-    * 
+    *
     * Depending on <var>$type</var>, <var>$opt</var> should be:
     *   o Smb:          encryption method (NT or LM)
     *   o Unix:         encryption method (des or md5)
@@ -380,14 +380,14 @@ class File_Passwd
     *   o Authdigest:   the realm the user is in
     *   o Cvs:          n/a (empty)
     *   o Custom:       array of 2 elements: encryption function and delimiter
-    * 
+    *
     * @static   call this method statically for a reasonable fast authentication
-    * 
+    *
     * @throws   PEAR_Error
     * @access   public
-    * @return   return      mixed   true if authenticated, 
+    * @return   return      mixed   true if authenticated,
     *                               false if not or PEAR_error
-    * 
+    *
     * @param    string      $type   Unix, Cvs, Smb, Authbasic or Authdigest
     * @param    string      $file   path to passwd file
     * @param    string      $user   the user to authenticate

--- a/web/File/Passwd.php
+++ b/web/File/Passwd.php
@@ -3,8 +3,8 @@
 
 /**
  * File::Passwd
- *
- * PHP versions 8
+ * 
+ * PHP versions 7.2 and later
  *
  * LICENSE: This source file is subject to version 3.0 of the PHP license
  * that is available through the world-wide-web at the following URI:
@@ -97,17 +97,17 @@ $GLOBALS['_FILE_PASSWD_64'] =
     './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
 /**
-* The package File_Passwd provides classes and methods
+* The package File_Passwd provides classes and methods 
 * to handle many different kinds of passwd files.
-*
-* The File_Passwd class in certain is a factory container for its special
+* 
+* The File_Passwd class in certain is a factory container for its special 
 * purpose extension classes, each handling a specific passwd file format.
 * It also provides a static method for reasonable fast user authentication.
 * Beside that it offers some encryption methods used by the extensions.
 *
 * @author       Michael Wallner <mike@php.net>
 * @version      $Revision$
-*
+* 
 * Usage Example:
 * <code>
 *  $passwd = &File_Passwd::factory('Unix');
@@ -157,7 +157,7 @@ class File_Passwd
     {
         return $plain;
     }
-
+    
     /**
     * DES encryption
     *
@@ -172,7 +172,7 @@ class File_Passwd
         (is_null($salt) || strlen($salt) < 2) && $salt = File_Passwd::salt(2);
         return crypt($plain, $salt);
     }
-
+    
     /**
     * MD5 encryption
     *
@@ -180,26 +180,26 @@ class File_Passwd
     * @access   public
     * @return   string  crypted text
     * @param    string  $plain  plaintext to encrypt
-    * @param    string  $salt   the salt to use for encryption
+    * @param    string  $salt   the salt to use for encryption 
     *                           (>2 chars starting with $1$)
     */
     function crypt_md5($plain, $salt = null)
     {
         if (
-            is_null($salt) ||
-            strlen($salt) < 3 ||
+            is_null($salt) || 
+            strlen($salt) < 3 || 
             !preg_match('/^\$1\$/', $salt))
         {
             $salt = '$1$' . File_Passwd::salt(8);
         }
         return crypt($plain, $salt);
     }
-
+    
     /**
     * SHA1 encryption
     *
     * Returns a PEAR_Error if sha1() is not available (PHP<4.3).
-    *
+    * 
     * @static
     * @throws   PEAR_Error
     * @access   public
@@ -218,7 +218,7 @@ class File_Passwd
         return '{SHA}' . base64_encode($hash);
 
     }
-
+        
     /**
     * APR compatible MD5 encryption
     *
@@ -236,25 +236,25 @@ class File_Passwd
         } else {
             $salt = substr($salt, 0,8);
         }
-
+        
         $length  = strlen($plain);
         $context = $plain . '$apr1$' . $salt;
-
+        
         if (PEAR_ZE2) {
             $binary = md5($plain . $salt . $plain, true);
         } else {
             $binary = pack('H32', md5($plain . $salt . $plain));
         }
-
+        
         for ($i = $length; $i > 0; $i -= 16) {
             $context .= substr($binary, 0, min(16 , $i));
         }
         for ( $i = $length; $i > 0; $i >>= 1) {
             $context .= ($i & 1) ? chr(0) : $plain[0];
         }
-
+        
         $binary = PEAR_ZE2 ? md5($context, true) : pack('H32', md5($context));
-
+        
         for ($i = 0; $i < 1000; $i++) {
             $new = ($i & 1) ? $plain : $binary;
             if ($i % 3) {
@@ -266,7 +266,7 @@ class File_Passwd
             $new .= ($i & 1) ? $binary : $plain;
             $binary = PEAR_ZE2 ? md5($new, true) : pack('H32', md5($new));
         }
-
+        
         $p = array();
         for ($i = 0; $i < 5; $i++) {
             $k = $i + 6;
@@ -281,9 +281,9 @@ class File_Passwd
                 5
             );
         }
-
-        return
-            '$apr1$' . $salt . '$' . implode($p) .
+        
+        return 
+            '$apr1$' . $salt . '$' . implode($p) . 
             File_Passwd::_64(ord($binary[11]), 3);
     }
 
@@ -304,7 +304,7 @@ class File_Passwd
         }
         return $rs;
     }
-
+    
     /**
     * Convert to allowed 64 characters for encryption
     *
@@ -326,18 +326,18 @@ class File_Passwd
 
     /**
     * Factory for new extensions
-    *
+    * 
     * o Unix        for standard Unix passwd files
     * o CVS         for CVS pserver passwd files
     * o SMB         for SMB server passwd files
     * o Authbasic   for AuthUserFiles
     * o Authdigest  for AuthDigestFiles
     * o Custom      for custom formatted passwd files
-    *
+    * 
     * Returns a PEAR_Error if the desired class/file couldn't be loaded.
-    *
+    * 
     * @static   use &File_Passwd::factory() for instantiating your passwd object
-    *
+    * 
     * @throws   PEAR_Error
     * @access   public
     * @return   object    File_Passwd_$class - desired Passwd object
@@ -355,15 +355,15 @@ class File_Passwd
         }
         return new $class();
     }
-
+    
     /**
     * Fast authentication of a certain user
-    *
+    * 
     * Though this approach should be reasonable fast, it is NOT
     * with APR compatible MD5 encryption used for htpasswd style
     * password files encrypted in MD5. Generating one MD5 password
     * takes about 0.3 seconds!
-    *
+    * 
     * Returns a PEAR_Error if:
     *   o file doesn't exist
     *   o file couldn't be opened in read mode
@@ -372,7 +372,7 @@ class File_Passwd
     *   o file couldn't be closed (only if auth fails)
     *   o invalid <var>$type</var> was provided
     *   o invalid <var>$opt</var> was provided
-    *
+    * 
     * Depending on <var>$type</var>, <var>$opt</var> should be:
     *   o Smb:          encryption method (NT or LM)
     *   o Unix:         encryption method (des or md5)
@@ -380,14 +380,14 @@ class File_Passwd
     *   o Authdigest:   the realm the user is in
     *   o Cvs:          n/a (empty)
     *   o Custom:       array of 2 elements: encryption function and delimiter
-    *
+    * 
     * @static   call this method statically for a reasonable fast authentication
-    *
+    * 
     * @throws   PEAR_Error
     * @access   public
-    * @return   return      mixed   true if authenticated,
+    * @return   return      mixed   true if authenticated, 
     *                               false if not or PEAR_error
-    *
+    * 
     * @param    string      $type   Unix, Cvs, Smb, Authbasic or Authdigest
     * @param    string      $file   path to passwd file
     * @param    string      $user   the user to authenticate

--- a/web/File/Passwd/Custom.php
+++ b/web/File/Passwd/Custom.php
@@ -3,8 +3,8 @@
 
 /**
  * File::Passwd::Custom
- *
- * PHP versions 8
+ * 
+ * PHP versions 7.2 and later
  *
  * LICENSE: This source file is subject to version 3.0 of the PHP license
  * that is available through the world-wide-web at the following URI:
@@ -26,7 +26,7 @@
 */
 require_once 'File/Passwd/Common.php';
 
-/**
+/** 
 * Manipulate custom formatted passwd files
 *
 * Usage Example:
@@ -38,7 +38,7 @@ require_once 'File/Passwd/Common.php';
 * $cust->addUser('mike', 'pass');
 * $cust->save();
 * </code>
-*
+* 
 * @author   Michael Wallner <mike@php.net>
 * @version  $Revision$
 * @access   public
@@ -52,7 +52,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     * @var      string
     */
     var $_delim = ':';
-
+    
     /**
     * Encryption function
     *
@@ -60,7 +60,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     * @var      string
     */
     var $_enc = array('File_Passwd', 'crypt_md5');
-
+    
     /**
     * 'name map'
     *
@@ -68,7 +68,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     * @var      array
     */
     var $_map = array();
-
+    
     /**
     * Whether to use the 'name map' or not
     *
@@ -90,7 +90,7 @@ class File_Passwd_Custom extends File_Passwd_Common
 
     /**
     * Fast authentication of a certain user
-    *
+    * 
     * Returns a PEAR_Error if:
     *   o file doesn't exist
     *   o file couldn't be opened in read mode
@@ -108,7 +108,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     *                       FILE_PASSWD_E_INVALID_ENC_MODE
     * @static   call this method statically for a reasonable fast authentication
     * @access   public
-    * @return   mixed   Returns &true; if authenticated, &false; if not or
+    * @return   mixed   Returns &true; if authenticated, &false; if not or 
     *                   <classname>PEAR_Error</classname> on failure.
     * @param    string  $file   path to passwd file
     * @param    string  $user   user to authenticate
@@ -122,22 +122,22 @@ class File_Passwd_Custom extends File_Passwd_Common
         if (count($opts) != 2 || empty($opts[1])) {
             throw new File_Passwd_Exception('Insufficient options.', 0);
         }
-
+        
         $line = File_Passwd_Common::_auth($file, $user, $opts[1]);
-
+        
         if (!$line) {
             return $line;
         }
-
+        
         list(,$real)= explode($opts[1], $line);
         $crypted    = File_Passwd_Custom::_genPass($pass, $real, $opts[0]);
-
+        
         return ($crypted === $real);
     }
 
     /**
     * Set delimiter
-    *
+    * 
     * You can set a custom char to delimit the columns of a data set.
     * Defaults to a colon (':'). Be aware that this char mustn't be
     * in the values of your data sets.
@@ -155,7 +155,7 @@ class File_Passwd_Custom extends File_Passwd_Common
             $this->_delim = $delim[0];
         }
     }
-
+    
     /**
     * Get custom delimiter
     *
@@ -166,19 +166,19 @@ class File_Passwd_Custom extends File_Passwd_Common
     {
         return $this->_delim;
     }
-
+    
     /**
     * Set encryption function
     *
     * You can set a custom encryption function to use.
-    * The supplied function will be called by php's call_user_function(),
-    * so you can supply an array with a method of a class/object, too
+    * The supplied function will be called by php's call_user_function(), 
+    * so you can supply an array with a method of a class/object, too 
     * (i.e. array('File_Passwd', 'crypt_apr_md5').
-    *
-    *
+    * 
+    * 
     * @throws   PEAR_Error          FILE_PASSWD_E_INVALID_ENC_MODE
     * @access   public
-    * @return   mixed   Returns &true; on success or
+    * @return   mixed   Returns &true; on success or 
     *                   <classname>PEAR_Error</classname> on failure.
     * @param    mixed   $function    callable encryption function
     */
@@ -193,18 +193,18 @@ class File_Passwd_Custom extends File_Passwd_Common
                 FILE_PASSWD_E_INVALID_ENC_MODE
             );
         }
-
+        
         $this->_enc = $function;
         return true;
     }
-
+    
     /**
     * Get current custom encryption method
     *
     * Possible return values (examples):
     *   o 'md5'
     *   o 'File_Passwd::crypt_md5'
-    *
+    * 
     * @access   public
     * @return   string
     */
@@ -215,18 +215,18 @@ class File_Passwd_Custom extends File_Passwd_Common
         }
         return $this->_enc;
     }
-
+    
     /**
     * Whether to use the 'name map' of the extra properties or not
-    *
+    * 
     * @see      File_Passwd_Custom::useMap()
     * @see      setMap()
     * @see      getMap()
-    *
+    * 
     * @access   public
     * @return   boolean always true if you set a value (true/false) OR
     *                   the actual value if called without param
-    *
+    * 
     * @param    boolean $bool   whether to use the 'name map' or not
     */
     function useMap($bool = null)
@@ -237,17 +237,17 @@ class File_Passwd_Custom extends File_Passwd_Common
         $this->_usemap = (bool) $bool;
         return true;
     }
-
+    
     /**
     * Set the 'name map' to use with the extra properties of the user
-    *
+    * 
     * This map is used for naming the associative array of the extra properties.
     *
     * Returns a PEAR_Error if <var>$map</var> was not of type array.
-    *
+    * 
     * @see      getMap()
     * @see      useMap()
-    *
+    * 
     * @throws   PEAR_Error  FILE_PASSWD_E_PARAM_MUST_BE_ARRAY
     * @access   public
     * @return   mixed       true on success or PEAR_Error
@@ -263,13 +263,13 @@ class File_Passwd_Custom extends File_Passwd_Common
         $this->_map = $map;
         return true;
     }
-
+    
     /**
     * Get the 'name map' which is used for the extra properties of the user
     *
     * @see      setMap()
     * @see      useMap()
-    *
+    * 
     * @access   public
     * @return   array
     */
@@ -287,13 +287,13 @@ class File_Passwd_Custom extends File_Passwd_Common
     *   o file couldn't be locked exclusively
     *   o file couldn't be unlocked
     *   o file couldn't be closed
-    *
+    * 
     * @throws   PEAR_Error  FILE_PASSWD_E_FILE_NOT_OPENED |
     *                       FILE_PASSWD_E_FILE_NOT_LOCKED |
     *                       FILE_PASSWD_E_FILE_NOT_UNLOCKED |
     *                       FILE_PASSWD_E_FILE_NOT_CLOSED
     * @access   public
-    * @return   mixed   Returns &true; on success or
+    * @return   mixed   Returns &true; on success or 
     *                   <classname>PEAR_Error</classname> on failure.
     */
     function save()
@@ -315,7 +315,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     * Parse the Custom password file
     *
     * Returns a PEAR_Error if passwd file has invalid format.
-    *
+    * 
     * @throws   PEAR_Error  FILE_PASSWD_E_INVALID_FORMAT
     * @access   public
     * @return   mixed   Returns &true; on success or
@@ -348,7 +348,7 @@ class File_Passwd_Custom extends File_Passwd_Common
                 $values = array_merge(array($pass), $parts);
             }
             $this->_users[$user] = $values;
-
+            
         }
         $this->_contents = array();
         return true;
@@ -359,25 +359,25 @@ class File_Passwd_Custom extends File_Passwd_Common
     *
     * The username must start with an alphabetical character and must NOT
     * contain any other characters than alphanumerics, the underline and dash.
-    *
+    * 
     * If you use the 'name map' you should also use these naming in
     * the supplied extra array, because your values would get mixed up
     * if they are in the wrong order, which is always true if you
     * DON'T use the 'name map'!
-    *
+    * 
     * So be warned and USE the 'name map'!
-    *
+    * 
     * Returns a PEAR_Error if:
     *   o user already exists
     *   o user contains illegal characters
     *   o encryption mode is not supported
     *   o any element of the <var>$extra</var> array contains the delimiter char
-    *
+    * 
     * @throws   PEAR_Error  FILE_PASSWD_E_EXISTS_ALREADY |
     *                       FILE_PASSWD_E_INVALID_ENC_MODE |
     *                       FILE_PASSWD_E_INVALID_CHARS
     * @access   public
-    * @return   mixed   Returns &true; on success or
+    * @return   mixed   Returns &true; on success or 
     *                   <classname>PEAR_Error</classname> on failure.
     * @param    string  $user   the name of the user to add
     * @param    string  $pass   the password of the user to add
@@ -408,9 +408,9 @@ class File_Passwd_Custom extends File_Passwd_Common
                 );
             }
         }
-
+        
         $pass = $this->_genPass($pass);
-
+        
         /**
         * If you don't use the 'name map' the user array will be numeric.
         */
@@ -425,7 +425,7 @@ class File_Passwd_Custom extends File_Passwd_Common
                 $this->_users[$user][$key] = @$extra[$key];
             }
         }
-
+        
         return true;
     }
 
@@ -433,21 +433,21 @@ class File_Passwd_Custom extends File_Passwd_Common
     * Modify properties of a certain user
     *
     * # DON'T MODIFY THE PASSWORD WITH THIS METHOD!
-    *
+    * 
     * You should use this method only if the 'name map' is used, too.
-    *
+    * 
     * Returns a PEAR_Error if:
     *   o user doesn't exist
     *   o any property contains the custom delimiter character
-    *
+    * 
     * @see      changePasswd()
-    *
-    * @throws   PEAR_Error  FILE_PASSWD_E_EXISTS_NOT |
+    * 
+    * @throws   PEAR_Error  FILE_PASSWD_E_EXISTS_NOT | 
     *                       FILE_PASSWD_E_INVALID_CHARS
     * @access   public
     * @return   mixed       true on success or PEAR_Error
     * @param    string      $user           the user to modify
-    * @param    array       $properties     an associative array of
+    * @param    array       $properties     an associative array of 
     *                                       properties to modify
     */
     function modUser($user, $properties = array())
@@ -458,11 +458,11 @@ class File_Passwd_Custom extends File_Passwd_Common
                 FILE_PASSWD_E_EXISTS_NOT
             );
         }
-
+        
         if (!is_array($properties)) {
             setType($properties, 'array');
         }
-
+        
         foreach ($properties as $key => $value){
             if (strstr($value, $this->_delim)) {
                 throw new File_Passwd_Exception(
@@ -472,7 +472,7 @@ class File_Passwd_Custom extends File_Passwd_Common
             }
             $this->_users[$user][$key] = $value;
         }
-
+        
         return true;
     }
 
@@ -482,11 +482,11 @@ class File_Passwd_Custom extends File_Passwd_Common
     * Returns a PEAR_Error if:
     *   o user doesn't exists
     *   o encryption mode is not supported
-    *
+    * 
     * @throws   PEAR_Error  FILE_PASSWD_E_EXISTS_NOT |
     *                       FILE_PASSWD_E_INVALID_ENC_MODE
     * @access   public
-    * @return   mixed   Returns &true; on success or
+    * @return   mixed   Returns &true; on success or 
     *                   <classname>PEAR_Error</classname> on failure.
     * @param    string  $user   the user whose password should be changed
     * @param    string  $pass   the new plaintext password
@@ -499,21 +499,21 @@ class File_Passwd_Custom extends File_Passwd_Common
                 FILE_PASSWD_E_EXISTS_NOT
             );
         }
-
+        
         $pass = $this->_genPass($pass);
-
+        
         if ($this->_usemap) {
             $this->_users[$user]['pass'] = $pass;
         } else {
             $this->_users[$user][0] = $pass;
         }
-
+        
         return true;
     }
 
     /**
     * Verify the password of a certain user
-    *
+    * 
     * Returns a PEAR_Error if:
     *   o user doesn't exist
     *   o encryption mode is not supported
@@ -521,7 +521,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     * @throws   PEAR_Error  FILE_PASSWD_E_EXISTS_NOT |
     *                       FILE_PASSWD_E_INVALID_ENC_MODE
     * @access   public
-    * @return   mixed   Returns &true; if passwors equal, &false; if they don't
+    * @return   mixed   Returns &true; if passwors equal, &false; if they don't 
     *                   or <classname>PEAR_Error</classname> on fialure.
     * @param    string  $user   the user whose password should be verified
     * @param    string  $pass   the password to verify
@@ -534,22 +534,22 @@ class File_Passwd_Custom extends File_Passwd_Common
                 FILE_PASSWD_E_EXISTS_NOT
             );
         }
-        $real =
-            $this->_usemap ?
-            $this->_users[$user]['pass'] :
+        $real = 
+            $this->_usemap ? 
+            $this->_users[$user]['pass'] : 
             $this->_users[$user][0]
         ;
         return ($real === $this->_genPass($pass, $real));
     }
-
+    
     /**
     * Generate crypted password from the plaintext password
     *
     * Returns a PEAR_Error if actual encryption mode is not supported.
-    *
+    * 
     * @throws   PEAR_Error  FILE_PASSWD_E_INVALID_ENC_MODE
     * @access   private
-    * @return   mixed   Returns the crypted password or
+    * @return   mixed   Returns the crypted password or 
     *                   <classname>PEAR_Error</classname>
     * @param    string  $pass   the plaintext password
     * @param    string  $salt   the crypted password from which to gain the salt
@@ -560,7 +560,7 @@ class File_Passwd_Custom extends File_Passwd_Common
         if (is_null($func)) {
             $func = $this->_enc;
         }
-
+        
         if (!is_callable($func)) {
             if (is_array($func)) {
                 $func = implode('::', $func);
@@ -576,11 +576,11 @@ class File_Passwd_Custom extends File_Passwd_Common
         }
 
         $return = @call_user_func($func, $pass, $salt);
-
+        
         if (is_null($return) || $return === false) {
             $return = @call_user_func($func, $pass);
         }
-
+        
         return $return;
     }
 }

--- a/web/File/Passwd/Custom.php
+++ b/web/File/Passwd/Custom.php
@@ -3,8 +3,8 @@
 
 /**
  * File::Passwd::Custom
- * 
- * PHP versions 4 and 5
+ *
+ * PHP versions 8
  *
  * LICENSE: This source file is subject to version 3.0 of the PHP license
  * that is available through the world-wide-web at the following URI:
@@ -26,7 +26,7 @@
 */
 require_once 'File/Passwd/Common.php';
 
-/** 
+/**
 * Manipulate custom formatted passwd files
 *
 * Usage Example:
@@ -38,7 +38,7 @@ require_once 'File/Passwd/Common.php';
 * $cust->addUser('mike', 'pass');
 * $cust->save();
 * </code>
-* 
+*
 * @author   Michael Wallner <mike@php.net>
 * @version  $Revision$
 * @access   public
@@ -52,7 +52,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     * @var      string
     */
     var $_delim = ':';
-    
+
     /**
     * Encryption function
     *
@@ -60,7 +60,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     * @var      string
     */
     var $_enc = array('File_Passwd', 'crypt_md5');
-    
+
     /**
     * 'name map'
     *
@@ -68,7 +68,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     * @var      array
     */
     var $_map = array();
-    
+
     /**
     * Whether to use the 'name map' or not
     *
@@ -90,7 +90,7 @@ class File_Passwd_Custom extends File_Passwd_Common
 
     /**
     * Fast authentication of a certain user
-    * 
+    *
     * Returns a PEAR_Error if:
     *   o file doesn't exist
     *   o file couldn't be opened in read mode
@@ -108,7 +108,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     *                       FILE_PASSWD_E_INVALID_ENC_MODE
     * @static   call this method statically for a reasonable fast authentication
     * @access   public
-    * @return   mixed   Returns &true; if authenticated, &false; if not or 
+    * @return   mixed   Returns &true; if authenticated, &false; if not or
     *                   <classname>PEAR_Error</classname> on failure.
     * @param    string  $file   path to passwd file
     * @param    string  $user   user to authenticate
@@ -122,22 +122,22 @@ class File_Passwd_Custom extends File_Passwd_Common
         if (count($opts) != 2 || empty($opts[1])) {
             throw new File_Passwd_Exception('Insufficient options.', 0);
         }
-        
+
         $line = File_Passwd_Common::_auth($file, $user, $opts[1]);
-        
+
         if (!$line) {
             return $line;
         }
-        
+
         list(,$real)= explode($opts[1], $line);
         $crypted    = File_Passwd_Custom::_genPass($pass, $real, $opts[0]);
-        
+
         return ($crypted === $real);
     }
 
     /**
     * Set delimiter
-    * 
+    *
     * You can set a custom char to delimit the columns of a data set.
     * Defaults to a colon (':'). Be aware that this char mustn't be
     * in the values of your data sets.
@@ -152,10 +152,10 @@ class File_Passwd_Custom extends File_Passwd_Common
         if (empty($delim)) {
             $this->_delim = ':';
         } else {
-            $this->_delim = $delim{0};
+            $this->_delim = $delim[0];
         }
     }
-    
+
     /**
     * Get custom delimiter
     *
@@ -166,19 +166,19 @@ class File_Passwd_Custom extends File_Passwd_Common
     {
         return $this->_delim;
     }
-    
+
     /**
     * Set encryption function
     *
     * You can set a custom encryption function to use.
-    * The supplied function will be called by php's call_user_function(), 
-    * so you can supply an array with a method of a class/object, too 
+    * The supplied function will be called by php's call_user_function(),
+    * so you can supply an array with a method of a class/object, too
     * (i.e. array('File_Passwd', 'crypt_apr_md5').
-    * 
-    * 
+    *
+    *
     * @throws   PEAR_Error          FILE_PASSWD_E_INVALID_ENC_MODE
     * @access   public
-    * @return   mixed   Returns &true; on success or 
+    * @return   mixed   Returns &true; on success or
     *                   <classname>PEAR_Error</classname> on failure.
     * @param    mixed   $function    callable encryption function
     */
@@ -193,18 +193,18 @@ class File_Passwd_Custom extends File_Passwd_Common
                 FILE_PASSWD_E_INVALID_ENC_MODE
             );
         }
-        
+
         $this->_enc = $function;
         return true;
     }
-    
+
     /**
     * Get current custom encryption method
     *
     * Possible return values (examples):
     *   o 'md5'
     *   o 'File_Passwd::crypt_md5'
-    * 
+    *
     * @access   public
     * @return   string
     */
@@ -215,18 +215,18 @@ class File_Passwd_Custom extends File_Passwd_Common
         }
         return $this->_enc;
     }
-    
+
     /**
     * Whether to use the 'name map' of the extra properties or not
-    * 
+    *
     * @see      File_Passwd_Custom::useMap()
     * @see      setMap()
     * @see      getMap()
-    * 
+    *
     * @access   public
     * @return   boolean always true if you set a value (true/false) OR
     *                   the actual value if called without param
-    * 
+    *
     * @param    boolean $bool   whether to use the 'name map' or not
     */
     function useMap($bool = null)
@@ -237,17 +237,17 @@ class File_Passwd_Custom extends File_Passwd_Common
         $this->_usemap = (bool) $bool;
         return true;
     }
-    
+
     /**
     * Set the 'name map' to use with the extra properties of the user
-    * 
+    *
     * This map is used for naming the associative array of the extra properties.
     *
     * Returns a PEAR_Error if <var>$map</var> was not of type array.
-    * 
+    *
     * @see      getMap()
     * @see      useMap()
-    * 
+    *
     * @throws   PEAR_Error  FILE_PASSWD_E_PARAM_MUST_BE_ARRAY
     * @access   public
     * @return   mixed       true on success or PEAR_Error
@@ -263,13 +263,13 @@ class File_Passwd_Custom extends File_Passwd_Common
         $this->_map = $map;
         return true;
     }
-    
+
     /**
     * Get the 'name map' which is used for the extra properties of the user
     *
     * @see      setMap()
     * @see      useMap()
-    * 
+    *
     * @access   public
     * @return   array
     */
@@ -287,13 +287,13 @@ class File_Passwd_Custom extends File_Passwd_Common
     *   o file couldn't be locked exclusively
     *   o file couldn't be unlocked
     *   o file couldn't be closed
-    * 
+    *
     * @throws   PEAR_Error  FILE_PASSWD_E_FILE_NOT_OPENED |
     *                       FILE_PASSWD_E_FILE_NOT_LOCKED |
     *                       FILE_PASSWD_E_FILE_NOT_UNLOCKED |
     *                       FILE_PASSWD_E_FILE_NOT_CLOSED
     * @access   public
-    * @return   mixed   Returns &true; on success or 
+    * @return   mixed   Returns &true; on success or
     *                   <classname>PEAR_Error</classname> on failure.
     */
     function save()
@@ -315,7 +315,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     * Parse the Custom password file
     *
     * Returns a PEAR_Error if passwd file has invalid format.
-    * 
+    *
     * @throws   PEAR_Error  FILE_PASSWD_E_INVALID_FORMAT
     * @access   public
     * @return   mixed   Returns &true; on success or
@@ -348,7 +348,7 @@ class File_Passwd_Custom extends File_Passwd_Common
                 $values = array_merge(array($pass), $parts);
             }
             $this->_users[$user] = $values;
-            
+
         }
         $this->_contents = array();
         return true;
@@ -359,25 +359,25 @@ class File_Passwd_Custom extends File_Passwd_Common
     *
     * The username must start with an alphabetical character and must NOT
     * contain any other characters than alphanumerics, the underline and dash.
-    * 
+    *
     * If you use the 'name map' you should also use these naming in
     * the supplied extra array, because your values would get mixed up
     * if they are in the wrong order, which is always true if you
     * DON'T use the 'name map'!
-    * 
+    *
     * So be warned and USE the 'name map'!
-    * 
+    *
     * Returns a PEAR_Error if:
     *   o user already exists
     *   o user contains illegal characters
     *   o encryption mode is not supported
     *   o any element of the <var>$extra</var> array contains the delimiter char
-    * 
+    *
     * @throws   PEAR_Error  FILE_PASSWD_E_EXISTS_ALREADY |
     *                       FILE_PASSWD_E_INVALID_ENC_MODE |
     *                       FILE_PASSWD_E_INVALID_CHARS
     * @access   public
-    * @return   mixed   Returns &true; on success or 
+    * @return   mixed   Returns &true; on success or
     *                   <classname>PEAR_Error</classname> on failure.
     * @param    string  $user   the name of the user to add
     * @param    string  $pass   the password of the user to add
@@ -408,9 +408,9 @@ class File_Passwd_Custom extends File_Passwd_Common
                 );
             }
         }
-        
+
         $pass = $this->_genPass($pass);
-        
+
         /**
         * If you don't use the 'name map' the user array will be numeric.
         */
@@ -425,7 +425,7 @@ class File_Passwd_Custom extends File_Passwd_Common
                 $this->_users[$user][$key] = @$extra[$key];
             }
         }
-        
+
         return true;
     }
 
@@ -433,21 +433,21 @@ class File_Passwd_Custom extends File_Passwd_Common
     * Modify properties of a certain user
     *
     * # DON'T MODIFY THE PASSWORD WITH THIS METHOD!
-    * 
+    *
     * You should use this method only if the 'name map' is used, too.
-    * 
+    *
     * Returns a PEAR_Error if:
     *   o user doesn't exist
     *   o any property contains the custom delimiter character
-    * 
+    *
     * @see      changePasswd()
-    * 
-    * @throws   PEAR_Error  FILE_PASSWD_E_EXISTS_NOT | 
+    *
+    * @throws   PEAR_Error  FILE_PASSWD_E_EXISTS_NOT |
     *                       FILE_PASSWD_E_INVALID_CHARS
     * @access   public
     * @return   mixed       true on success or PEAR_Error
     * @param    string      $user           the user to modify
-    * @param    array       $properties     an associative array of 
+    * @param    array       $properties     an associative array of
     *                                       properties to modify
     */
     function modUser($user, $properties = array())
@@ -458,11 +458,11 @@ class File_Passwd_Custom extends File_Passwd_Common
                 FILE_PASSWD_E_EXISTS_NOT
             );
         }
-        
+
         if (!is_array($properties)) {
             setType($properties, 'array');
         }
-        
+
         foreach ($properties as $key => $value){
             if (strstr($value, $this->_delim)) {
                 throw new File_Passwd_Exception(
@@ -472,7 +472,7 @@ class File_Passwd_Custom extends File_Passwd_Common
             }
             $this->_users[$user][$key] = $value;
         }
-        
+
         return true;
     }
 
@@ -482,11 +482,11 @@ class File_Passwd_Custom extends File_Passwd_Common
     * Returns a PEAR_Error if:
     *   o user doesn't exists
     *   o encryption mode is not supported
-    * 
+    *
     * @throws   PEAR_Error  FILE_PASSWD_E_EXISTS_NOT |
     *                       FILE_PASSWD_E_INVALID_ENC_MODE
     * @access   public
-    * @return   mixed   Returns &true; on success or 
+    * @return   mixed   Returns &true; on success or
     *                   <classname>PEAR_Error</classname> on failure.
     * @param    string  $user   the user whose password should be changed
     * @param    string  $pass   the new plaintext password
@@ -499,21 +499,21 @@ class File_Passwd_Custom extends File_Passwd_Common
                 FILE_PASSWD_E_EXISTS_NOT
             );
         }
-        
+
         $pass = $this->_genPass($pass);
-        
+
         if ($this->_usemap) {
             $this->_users[$user]['pass'] = $pass;
         } else {
             $this->_users[$user][0] = $pass;
         }
-        
+
         return true;
     }
 
     /**
     * Verify the password of a certain user
-    * 
+    *
     * Returns a PEAR_Error if:
     *   o user doesn't exist
     *   o encryption mode is not supported
@@ -521,7 +521,7 @@ class File_Passwd_Custom extends File_Passwd_Common
     * @throws   PEAR_Error  FILE_PASSWD_E_EXISTS_NOT |
     *                       FILE_PASSWD_E_INVALID_ENC_MODE
     * @access   public
-    * @return   mixed   Returns &true; if passwors equal, &false; if they don't 
+    * @return   mixed   Returns &true; if passwors equal, &false; if they don't
     *                   or <classname>PEAR_Error</classname> on fialure.
     * @param    string  $user   the user whose password should be verified
     * @param    string  $pass   the password to verify
@@ -534,22 +534,22 @@ class File_Passwd_Custom extends File_Passwd_Common
                 FILE_PASSWD_E_EXISTS_NOT
             );
         }
-        $real = 
-            $this->_usemap ? 
-            $this->_users[$user]['pass'] : 
+        $real =
+            $this->_usemap ?
+            $this->_users[$user]['pass'] :
             $this->_users[$user][0]
         ;
         return ($real === $this->_genPass($pass, $real));
     }
-    
+
     /**
     * Generate crypted password from the plaintext password
     *
     * Returns a PEAR_Error if actual encryption mode is not supported.
-    * 
+    *
     * @throws   PEAR_Error  FILE_PASSWD_E_INVALID_ENC_MODE
     * @access   private
-    * @return   mixed   Returns the crypted password or 
+    * @return   mixed   Returns the crypted password or
     *                   <classname>PEAR_Error</classname>
     * @param    string  $pass   the plaintext password
     * @param    string  $salt   the crypted password from which to gain the salt
@@ -560,7 +560,7 @@ class File_Passwd_Custom extends File_Passwd_Common
         if (is_null($func)) {
             $func = $this->_enc;
         }
-        
+
         if (!is_callable($func)) {
             if (is_array($func)) {
                 $func = implode('::', $func);
@@ -576,11 +576,11 @@ class File_Passwd_Custom extends File_Passwd_Common
         }
 
         $return = @call_user_func($func, $pass, $salt);
-        
+
         if (is_null($return) || $return === false) {
             $return = @call_user_func($func, $pass);
         }
-        
+
         return $return;
     }
 }

--- a/web/File/Passwd/Smb.php
+++ b/web/File/Passwd/Smb.php
@@ -3,8 +3,8 @@
 
 /**
  * File::Passwd::Smb
- * 
- * PHP version 5
+ *
+ * PHP version 8
  *
  * LICENSE: This source file is subject to version 3.0 of the PHP license
  * that is available through the world-wide-web at the following URI:
@@ -48,7 +48,7 @@ require_once 'Crypt/CHAP.php';
 * }
 * $f->save();
 * </code>
-* 
+*
 * # Usage Example 2 (creating a new file):
 * <code>
 * $f = &File_Passwd::factory('SMB');
@@ -57,7 +57,7 @@ require_once 'Crypt/CHAP.php';
 * $f->addUser('sepp3', 'MyPw', array('userid' => 1000));
 * $f->save();
 * </code>
-* 
+*
 * # Usage Example 3 (authentication):
 * <code>
 * $f = &File_Passwd::factory('SMB');
@@ -69,7 +69,7 @@ require_once 'Crypt/CHAP.php';
 *     echo "User invalid or disabled";
 * }
 * </code>
-* 
+*
 * @author   Michael Bretterklieber <michael@bretterklieber.com>
 * @author   Michael Wallner <mike@php.net>
 * @package  File_Passwd
@@ -80,15 +80,15 @@ class File_Passwd_Smb extends File_Passwd_Common
 {
     /**
     * Object which generates the NT-Hash and LAN-Manager-Hash passwds
-    * 
+    *
     * @access protected
     * @var object
     */
     var $msc;
-    
+
     /**
     * Constructor (ZE2)
-    * 
+    *
     * Rewritten because we want to init our crypt engine.
     *
     * @access public
@@ -98,11 +98,11 @@ class File_Passwd_Smb extends File_Passwd_Common
     {
         $this->setFile($file);
         $this->msc = new Crypt_CHAP_MSv1;
-    }     
-    
+    }
+
     /**
     * Fast authentication of a certain user
-    * 
+    *
     * Returns a PEAR_Error if:
     *   o file doesn't exist
     *   o file couldn't be opened in read mode
@@ -127,15 +127,15 @@ class File_Passwd_Smb extends File_Passwd_Common
         }
         @list(,,$lm,$nt) = explode(':', $line);
         $chap            = new Crypt_CHAP_MSv1;
-        
+
         switch(strToLower($nt_or_lm)){
-        	case FILE_PASSWD_NT: 
-                $real       = $nt; 
-                $crypted    = $chap->ntPasswordHash($pass); 
+        	case FILE_PASSWD_NT:
+                $real       = $nt;
+                $crypted    = $chap->ntPasswordHash($pass);
                 break;
-        	case FILE_PASSWD_LM: 
+        	case FILE_PASSWD_LM:
                 $real       = $lm;
-                $crypted    = $chap->lmPasswordHash($pass); 
+                $crypted    = $chap->lmPasswordHash($pass);
                 break;
         	default:
                 throw new File_Passwd_Exception(
@@ -145,15 +145,15 @@ class File_Passwd_Smb extends File_Passwd_Common
         }
         return (strToUpper(bin2hex($crypted)) === $real);
     }
-    
+
     /**
     * Parse smbpasswd file
     *
     * Returns a PEAR_Error if passwd file has invalid format.
-    * 
+    *
     * @access public
     * @return mixed   true on success or PEAR_Error
-    */    
+    */
     function parse()
     {
         foreach ($this->_contents as $line){
@@ -178,9 +178,9 @@ class File_Passwd_Smb extends File_Passwd_Common
             }
         }
         $this->_contents = array();
-        return true; 
+        return true;
     }
-    
+
     /**
     * Add a user
     *
@@ -229,14 +229,14 @@ class File_Passwd_Smb extends File_Passwd_Common
 
     /**
     * Modify a certain user
-    * 
-    * <b>You should not modify the password with this method 
+    *
+    * <b>You should not modify the password with this method
     * unless it is already encrypted as nthash and lmhash!</b>
     *
     * Returns a PEAR_Error if:
     *   o user doesn't exist
     *   o an invalid property was supplied
-    * 
+    *
     * @throws PEAR_Error
     * @access public
     * @return mixed true on success or PEAR_Error
@@ -275,7 +275,7 @@ class File_Passwd_Smb extends File_Passwd_Common
     * Change the passwd of a certain user
     *
     * Returns a PEAR_Error if <var>$user</var> doesn't exist.
-    * 
+    *
     * @throws PEAR_Error
     * @access public
     * @return mixed true on success or PEAR_Error
@@ -300,10 +300,10 @@ class File_Passwd_Smb extends File_Passwd_Common
         $this->_users[$user]['lmhash'] = $lmhash;
         return true;
     }
-    
+
     /**
     * Verifies a user's password
-    * 
+    *
     * Prefer NT-Hash instead of weak LAN-Manager-Hash
     *
     * Returns a PEAR_Error if:
@@ -311,7 +311,7 @@ class File_Passwd_Smb extends File_Passwd_Common
     *   o user is disabled
     *
     * @return mixed true if passwds equal, false if they don't or PEAR_Error
-    * @access public		
+    * @access public
     * @param string $user       username
     * @param string $nthash     NT-Hash in hex
     * @param string $lmhash     LAN-Manager-Hash in hex
@@ -345,7 +345,7 @@ class File_Passwd_Smb extends File_Passwd_Common
     *
     * @throws PEAR_Error
     * @return mixed     true if passwds equal, false if they don't or PEAR_Error
-    * @access public		
+    * @access public
     * @param  string    $user username
     * @param  string    $pass the plaintext password
     */
@@ -365,7 +365,7 @@ class File_Passwd_Smb extends File_Passwd_Common
     *   o file couldn't be locked exclusively
     *   o file couldn't be unlocked
     *   o file couldn't be closed
-    * 
+    *
     * @throws PEAR_Error
     * @access public
     * @return mixed true on success or PEAR_Error
@@ -384,7 +384,7 @@ class File_Passwd_Smb extends File_Passwd_Common
         }
         return $this->_save($content);
     }
-    
+
     /**
     * Generate Password
     *
@@ -396,13 +396,13 @@ class File_Passwd_Smb extends File_Passwd_Common
     */
     function generatePasswd($pass, $mode = 'nt')
     {
-        $chap = &new Crypt_CHAP_MSv1;
-        $hash = strToLower($mode) == 'nt' ? 
+        $chap = new Crypt_CHAP_MSv1;
+        $hash = strToLower($mode) == 'nt' ?
             $chap->ntPasswordHash($pass) :
             $chap->lmPasswordHash($pass);
         return strToUpper(bin2hex($hash));
     }
-    
+
     /**
      * @ignore
      * @deprecated

--- a/web/File/Passwd/Smb.php
+++ b/web/File/Passwd/Smb.php
@@ -3,8 +3,8 @@
 
 /**
  * File::Passwd::Smb
- *
- * PHP version 8
+ * 
+ * PHP version 7.2 and later
  *
  * LICENSE: This source file is subject to version 3.0 of the PHP license
  * that is available through the world-wide-web at the following URI:
@@ -48,7 +48,7 @@ require_once 'Crypt/CHAP.php';
 * }
 * $f->save();
 * </code>
-*
+* 
 * # Usage Example 2 (creating a new file):
 * <code>
 * $f = &File_Passwd::factory('SMB');
@@ -57,7 +57,7 @@ require_once 'Crypt/CHAP.php';
 * $f->addUser('sepp3', 'MyPw', array('userid' => 1000));
 * $f->save();
 * </code>
-*
+* 
 * # Usage Example 3 (authentication):
 * <code>
 * $f = &File_Passwd::factory('SMB');
@@ -69,7 +69,7 @@ require_once 'Crypt/CHAP.php';
 *     echo "User invalid or disabled";
 * }
 * </code>
-*
+* 
 * @author   Michael Bretterklieber <michael@bretterklieber.com>
 * @author   Michael Wallner <mike@php.net>
 * @package  File_Passwd
@@ -80,15 +80,15 @@ class File_Passwd_Smb extends File_Passwd_Common
 {
     /**
     * Object which generates the NT-Hash and LAN-Manager-Hash passwds
-    *
+    * 
     * @access protected
     * @var object
     */
     var $msc;
-
+    
     /**
     * Constructor (ZE2)
-    *
+    * 
     * Rewritten because we want to init our crypt engine.
     *
     * @access public
@@ -98,11 +98,11 @@ class File_Passwd_Smb extends File_Passwd_Common
     {
         $this->setFile($file);
         $this->msc = new Crypt_CHAP_MSv1;
-    }
-
+    }     
+    
     /**
     * Fast authentication of a certain user
-    *
+    * 
     * Returns a PEAR_Error if:
     *   o file doesn't exist
     *   o file couldn't be opened in read mode
@@ -127,15 +127,15 @@ class File_Passwd_Smb extends File_Passwd_Common
         }
         @list(,,$lm,$nt) = explode(':', $line);
         $chap            = new Crypt_CHAP_MSv1;
-
+        
         switch(strToLower($nt_or_lm)){
-        	case FILE_PASSWD_NT:
-                $real       = $nt;
-                $crypted    = $chap->ntPasswordHash($pass);
+        	case FILE_PASSWD_NT: 
+                $real       = $nt; 
+                $crypted    = $chap->ntPasswordHash($pass); 
                 break;
-        	case FILE_PASSWD_LM:
+        	case FILE_PASSWD_LM: 
                 $real       = $lm;
-                $crypted    = $chap->lmPasswordHash($pass);
+                $crypted    = $chap->lmPasswordHash($pass); 
                 break;
         	default:
                 throw new File_Passwd_Exception(
@@ -145,15 +145,15 @@ class File_Passwd_Smb extends File_Passwd_Common
         }
         return (strToUpper(bin2hex($crypted)) === $real);
     }
-
+    
     /**
     * Parse smbpasswd file
     *
     * Returns a PEAR_Error if passwd file has invalid format.
-    *
+    * 
     * @access public
     * @return mixed   true on success or PEAR_Error
-    */
+    */    
     function parse()
     {
         foreach ($this->_contents as $line){
@@ -178,9 +178,9 @@ class File_Passwd_Smb extends File_Passwd_Common
             }
         }
         $this->_contents = array();
-        return true;
+        return true; 
     }
-
+    
     /**
     * Add a user
     *
@@ -229,14 +229,14 @@ class File_Passwd_Smb extends File_Passwd_Common
 
     /**
     * Modify a certain user
-    *
-    * <b>You should not modify the password with this method
+    * 
+    * <b>You should not modify the password with this method 
     * unless it is already encrypted as nthash and lmhash!</b>
     *
     * Returns a PEAR_Error if:
     *   o user doesn't exist
     *   o an invalid property was supplied
-    *
+    * 
     * @throws PEAR_Error
     * @access public
     * @return mixed true on success or PEAR_Error
@@ -275,7 +275,7 @@ class File_Passwd_Smb extends File_Passwd_Common
     * Change the passwd of a certain user
     *
     * Returns a PEAR_Error if <var>$user</var> doesn't exist.
-    *
+    * 
     * @throws PEAR_Error
     * @access public
     * @return mixed true on success or PEAR_Error
@@ -300,10 +300,10 @@ class File_Passwd_Smb extends File_Passwd_Common
         $this->_users[$user]['lmhash'] = $lmhash;
         return true;
     }
-
+    
     /**
     * Verifies a user's password
-    *
+    * 
     * Prefer NT-Hash instead of weak LAN-Manager-Hash
     *
     * Returns a PEAR_Error if:
@@ -311,7 +311,7 @@ class File_Passwd_Smb extends File_Passwd_Common
     *   o user is disabled
     *
     * @return mixed true if passwds equal, false if they don't or PEAR_Error
-    * @access public
+    * @access public		
     * @param string $user       username
     * @param string $nthash     NT-Hash in hex
     * @param string $lmhash     LAN-Manager-Hash in hex
@@ -345,7 +345,7 @@ class File_Passwd_Smb extends File_Passwd_Common
     *
     * @throws PEAR_Error
     * @return mixed     true if passwds equal, false if they don't or PEAR_Error
-    * @access public
+    * @access public		
     * @param  string    $user username
     * @param  string    $pass the plaintext password
     */
@@ -365,7 +365,7 @@ class File_Passwd_Smb extends File_Passwd_Common
     *   o file couldn't be locked exclusively
     *   o file couldn't be unlocked
     *   o file couldn't be closed
-    *
+    * 
     * @throws PEAR_Error
     * @access public
     * @return mixed true on success or PEAR_Error
@@ -384,7 +384,7 @@ class File_Passwd_Smb extends File_Passwd_Common
         }
         return $this->_save($content);
     }
-
+    
     /**
     * Generate Password
     *
@@ -397,12 +397,12 @@ class File_Passwd_Smb extends File_Passwd_Common
     function generatePasswd($pass, $mode = 'nt')
     {
         $chap = new Crypt_CHAP_MSv1;
-        $hash = strToLower($mode) == 'nt' ?
+        $hash = strToLower($mode) == 'nt' ? 
             $chap->ntPasswordHash($pass) :
             $chap->lmPasswordHash($pass);
         return strToUpper(bin2hex($hash));
     }
-
+    
     /**
      * @ignore
      * @deprecated


### PR DESCRIPTION
Fix PHP compatibility errors in the bundled `File_Passwd` library.

PHP 8 no longer supports curly-brace string offset syntax, causing parse errors when loading the base or custom password-file classes. The
SMB implementation also used the obsolete `=& new` syntax.

## Changes

- Replace curly-brace string offsets with square-bracket syntax in:
  - `File/Passwd.php`
  - `File/Passwd/Custom.php`
- Remove the obsolete reference assignment when creating `Crypt_CHAP_MSv1` in `File/Passwd/Smb.php`.
- Update PHP compatibility notes.

## Testing

- Ran `php -l` against all 800 PHP and INC files.
- Confirmed there are no remaining syntax errors.
- Confirmed `git diff --check` passes.
