### PR TITLE
docs: add security policy guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the current MRBS release line.
+Please check the latest release and upgrade notes before reporting an issue:
+
+- [Latest MRBS releases](https://github.com/meeting-room-booking-system/mrbs-code/releases)
+- [Upgrade instructions](UPGRADE)
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in MRBS, please report it privately through GitHub's [private vulnerability reporting form](https://github.com/meeting-room-booking-system/mrbs-code/security/advisories/new) instead of opening a public issue.
+
+General support requests and non-security bugs should continue to use the public issue tracker. Use the private vulnerability reporting form only for security-sensitive reports that should not be disclosed before maintainers can investigate.
+
+When reporting a vulnerability, include as much detail as possible, such as:
+
+- The affected MRBS version or commit
+- Steps to reproduce the issue
+- Any relevant configuration details
+- The potential impact
+- Suggested fixes or mitigations, if known
+
+Please avoid disclosing the vulnerability publicly until the maintainers have had a reasonable opportunity to investigate and release a fix.


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` file so GitHub can surface clear security reporting guidance for MRBS.

## Details

- Documents that security updates are intended for the current MRBS release line
- Links reporters to the latest releases and upgrade notes before they file a report
- Asks vulnerability reporters to avoid public issues and include key reproduction/impact details
- Encourages coordinated disclosure before public discussion

## Testing

- Documentation-only change
- Ran `git diff --check`
