### PR TITLE
4016 roles adds great value but is too slow for a production environment get lock on mrbs session takes 515s per request

### DIFF
--- a/web/lib/MRBS/SessionHandler/SessionHandlerDb.php
+++ b/web/lib/MRBS/SessionHandler/SessionHandlerDb.php
@@ -112,6 +112,12 @@ class SessionHandlerDb implements SessionHandlerInterface, SessionUpdateTimestam
   // returned internally to PHP for processing.
   public function close(): bool
   {
+    if (false !== ($id = session_id()))
+    {
+      // Release the mutex lock
+      db()->mutex_unlock($id);
+    }
+
     return true;
   }
 
@@ -285,13 +291,6 @@ class SessionHandlerDb implements SessionHandlerInterface, SessionUpdateTimestam
   // See https://github.com/php/php-src/issues/9668
   public function validateId($id) : bool
   {
-    // Acquire a lock
-    if (!db()->mutex_lock($id))
-    {
-      trigger_error("Failed to acquire a lock", E_USER_WARNING);
-      return false;
-    }
-
     $sql = "SELECT COUNT(*)
               FROM " . self::$table . "
              WHERE id=:id
@@ -305,13 +304,6 @@ class SessionHandlerDb implements SessionHandlerInterface, SessionUpdateTimestam
   // which we are implementing in order to provide validateId().
   public function updateTimestamp($id, $data) : bool
   {
-    // Acquire a lock
-    if (!db()->mutex_lock($id))
-    {
-      trigger_error("Failed to acquire a lock", E_USER_WARNING);
-      return false;
-    }
-
     try
     {
       $sql = "UPDATE " . self::$table . "
@@ -330,9 +322,6 @@ class SessionHandlerDb implements SessionHandlerInterface, SessionUpdateTimestam
       trigger_error($e->getMessage(), E_USER_WARNING);
       $result = false;
     }
-
-    // Release the mutex lock
-    db()->mutex_unlock($id);
 
     return $result;
   }

--- a/web/mrbs_auth.inc
+++ b/web/mrbs_auth.inc
@@ -204,19 +204,32 @@ function checkAuthorised($page, $just_check=false)
 
   if ($just_check)
   {
-    if ($required_level == 0)
-    {
-      return true;
+    if ($required_level == 0) {
+      $result = true;
     }
-
-    $mrbs_user = session()->getCurrentUser();
-    return (isset($mrbs_user) && ($mrbs_user->level >= $required_level));
+    else
+    {
+      $mrbs_user = session()->getCurrentUser();
+      $result = (isset($mrbs_user) && ($mrbs_user->level >= $required_level));
+    }
   }
 
   // Check that the user has this level
-  if (getAuthorised($required_level, $returl))
+  elseif (getAuthorised($required_level, $returl))
   {
-    return true;
+    $result = true;
+  }
+
+  // We don't need to change the session data after this point, so close the session so
+  // that the lock is released.  We will still be able to read the session data.
+  if (session_status() === PHP_SESSION_ACTIVE)
+  {
+    session_write_close();
+  }
+
+  if (isset($result))
+  {
+    return $result;
   }
 
   // If we don't know the right date then use today's


### PR DESCRIPTION
Fix #4016 by changing the locking stategy in the custom session handler and releasing the lock by calling session_write_close() once the session data won't need to be changed.